### PR TITLE
feat: Expose public top-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ Implementation status: A subset of wasi_snapshot_preview1 is implemented. The re
 
 ## Usage
 
+```
+npm install @bjorn3/browser_wasi_shim --save
+```
+
 ```javascript
-import WASI from "./browser_wasi_shim/src/wasi.js";
-import { File } from "./browser_wasi_shim/src/fs_core.js";
+import { WASI, File, PreopenDirectory } from "@bjorn3/browser_wasi_shim";
 
 let args = ["bin", "arg1", "arg2"];
 let env = ["FOO=bar"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bjorn3/browser_wasi_shim",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT OR Apache-2.0",
   "description": "A pure javascript shim for WASI",
   "scripts": {
@@ -14,6 +14,7 @@
   "bugs": {
     "url": "https://github.com/bjorn3/browser_wasi_shim/issues"
   },
+  "main": "src/index.js",
   "homepage": "https://github.com/bjorn3/browser_wasi_shim#readme",
   "devDependencies": {
     "flow-bin": "^0.159.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import WASI from "./wasi.js"
 import { File } from "./fs_core.js"
 import { PreopenDirectory } from "./fs_fd.js"
+import { strace } from "./strace.js"
 
 module.exports = {
     WASI,
     File,
     PreopenDirectory,
+    strace,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import WASI from "./wasi.js"
+import { File } from "./fs_core.js"
+import { PreopenDirectory } from "./fs_fd.js"
+
+module.exports = {
+    WASI,
+    File,
+    PreopenDirectory,
+}
+


### PR DESCRIPTION
This PR creates an index.js to establish a top level, public API for the library. It also updates the example to use the npm library.

Open to exporting other stuff in the public API. I'm not yet sure what is meant to be exposed and what isn't.

> **Note**: I bumped the version to 0.2.0 and you'll need to publish it
for the README example to work.