### PR TITLE
fix: ESM projects prefer "exports"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules
 *.wasm
 *.wasm.gz
 /examples
+.github/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bjorn3/browser_wasi_shim",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bjorn3/browser_wasi_shim",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "flow-bin": "^0.159.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bjorn3/browser_wasi_shim",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT OR Apache-2.0",
   "description": "A pure javascript shim for WASI",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
   "bugs": {
     "url": "https://github.com/bjorn3/browser_wasi_shim/issues"
   },
-  "main": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    }
+  },
   "homepage": "https://github.com/bjorn3/browser_wasi_shim#readme",
   "devDependencies": {
     "flow-bin": "^0.159.0"


### PR DESCRIPTION
Seems our ESM based library prefer this and gets confused by main. Still seems to work for CJS builds too. Our library builds both CJS and ESM modules.