### PR TITLE
Fix file_pos used as both Number and BigInt arithmetic

### DIFF
--- a/src/fs_fd.js
+++ b/src/fs_fd.js
@@ -21,9 +21,9 @@ export class OpenFile extends Fd {
         let nread = 0;
         for (let iovec of iovs) {
             if (this.file_pos < this.file.data.byteLength) {
-                let slice = this.file.data.slice(this.file_pos, this.file_pos + iovec.buf_len);
+                let slice = this.file.data.slice(Number(this.file_pos), Number(this.file_pos + BigInt(iovec.buf_len)));
                 view8.set(slice, iovec.buf);
-                this.file_pos += slice.length;
+                this.file_pos += BigInt(slice.length);
                 nread += slice.length;
             } else {
                 break;
@@ -60,18 +60,18 @@ export class OpenFile extends Fd {
         let nwritten = 0;
         for (let iovec of iovs) {
             let buffer = view8.slice(iovec.buf, iovec.buf + iovec.buf_len);
-            if (this.file_pos + buffer.byteLength > this.file.size) {
+            if (this.file_pos + BigInt(buffer.byteLength) > this.file.size) {
                 let old = this.file.data;
-                this.file.data = new Uint8Array(this.file_pos + buffer.byteLength);
+                this.file.data = new Uint8Array(Number(this.file_pos + BigInt(buffer.byteLength)));
                 this.file.data.set(old);
             }
             this.file.data.set(
                 buffer.slice(
                     0,
-                    this.file.size - this.file_pos,
-                ), this.file_pos
+                    this.file.size - Number(this.file_pos),
+                ), Number(this.file_pos)
             );
-            this.file_pos += buffer.byteLength;
+            this.file_pos += BigInt(buffer.byteLength);
             nwritten += iovec.buf_len;
         }
         return { ret: 0, nwritten };

--- a/src/fs_fd.js
+++ b/src/fs_fd.js
@@ -6,7 +6,7 @@ import { Fd } from "./fd.js";
 
 export class OpenFile extends Fd {
     /*:: file: File*/;
-    file_pos/*: number*/ = 0;
+    file_pos/*: number*/ = 0n;
 
     constructor(file/*: File*/) {
         super();

--- a/src/fs_fd.js
+++ b/src/fs_fd.js
@@ -6,7 +6,7 @@ import { Fd } from "./fd.js";
 
 export class OpenFile extends Fd {
     /*:: file: File*/;
-    file_pos/*: number*/ = 0n;
+    file_pos/*: BigInt*/ = 0n;
 
     constructor(file/*: File*/) {
         super();
@@ -32,7 +32,7 @@ export class OpenFile extends Fd {
         return { ret: 0, nread };
     }
 
-    fd_seek(offset/*: number*/, whence/*: number*/)/*: {ret: number, offset: number }*/ {
+    fd_seek(offset/*: BigInt*/, whence/*: number*/)/*: {ret: number, offset: BigInt }*/ {
         let calculated_offset;
         switch (whence) {
             case wasi.WHENCE_SET:


### PR DESCRIPTION
Honestly, I don't really like this 'fix'. There's several style problems and no real consistency. But:

## Reproduction

I've initialized `stdin`/`stdout` to point to open files. Then an instace of [rust WASI example](https://github.com/wapm-packages/rust-wasi-example) compiled with wasm32-wasi (Rust 1.65) will try to print to stdout, repeating `Hello, world!` three times.

This crashed in the file operations, in particular during some initial seek, which passes its offset as `i64`(wasm)/`BigInt`(js). The fix is currently to consistently use a 64-bit type for the internal representation of the offset but the checks are missing. This PR is to raise some awareness and remind me to contribute a proper fix.

```rust
import { WASI, File, PreopenDirectory } from "@bjorn3/browser_wasi_shim";

async function mount(promise) {
  let args = ["hq9+", "-f", "test.hq9+"];
  let env = ["FOO=bar"];

  var stdin = new File([]);
  var stdout = new File([]);
  var stderr = new File([]);
  
  let dir = new PreopenDirectory(".", {
      "stdin": stdin,
      "stdout": stdout,
      "stderr": stderr,
      "test.hq9+": new File(new TextEncoder("utf-8").encode(`HHHH+Q`)),
    });

  let fds = [
    dir.path_open(0, "stdin", 0).fd_obj,
    dir.path_open(0, "stdout", 0).fd_obj,
    dir.path_open(0, "stderr", 0).fd_obj,
    dir,
  ];

  let wasi = new WASI(args, env, fds);

  let wasm = await WebAssembly.compileStreaming(await promise);
  let inst = await WebAssembly.instantiate(wasm, {
    "wasi_snapshot_preview1": wasi.wasiImport,
  });  

  try {
    wasi.start(inst);
  } finally {
    let decoder = new TextDecoder();
    console.log(stdin, stdout, stderr);
    console.log(decoder.decode(stdin.data));
    console.log(decoder.decode(stdout.data));
    console.log(decoder.decode(stderr.data));
  }
}

export default mount;
```

## Reproduction

Run it against this wasm module. [wasi.zip](https://github.com/bjorn3/browser_wasi_shim/files/10494102/wasi.zip) (`out.html` is a valid wasm module). Or open it as HTML which bundles my fixed version of the wasi shim instead.