### PR TITLE
Fix webpack when using browser_wasi_shim as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.2",
   "license": "MIT OR Apache-2.0",
   "description": "A pure javascript shim for WASI",
+  "type": "module",
   "scripts": {
     "flow": "flow"
   },

--- a/src/fs_core.js
+++ b/src/fs_core.js
@@ -6,7 +6,7 @@ export class File {
     /*:: data: Uint8Array*/;
 
     constructor(data/*: ArrayBuffer | Uint8Array*/) {
-        console.log(data);
+        //console.log(data);
         this.data = new Uint8Array(data);
     }
 
@@ -41,7 +41,7 @@ export class Directory {
             if (entry.contents[component] != undefined) {
                 entry = entry.contents[component];
             } else {
-                console.log(component);
+                //console.log(component);
                 return null;
             }
         }
@@ -57,7 +57,7 @@ export class Directory {
             if (entry.contents[component] != undefined) {
                 entry = entry.contents[component];
             } else {
-                console.log("create", component);
+                //console.log("create", component);
                 if (i == components.length - 1) {
                     entry.contents[component] = new File(new ArrayBuffer(0));
                 } else {

--- a/src/fs_fd.js
+++ b/src/fs_fd.js
@@ -95,7 +95,7 @@ export class OpenDirectory extends Fd {
     }
 
     fd_readdir_single(cookie/*: BigInt*/)/*: { ret: number, dirent: wasi.Dirent | null }*/ {
-        console.log(cookie, Object.keys(this.dir.contents).slice(Number(cookie)));
+        //console.log(cookie, Object.keys(this.dir.contents).slice(Number(cookie)));
         if (cookie >= BigInt(Object.keys(this.dir.contents).length)) {
             return { ret: 0, dirent: null };
         }

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,9 @@ import { File } from "./fs_core.js"
 import { PreopenDirectory } from "./fs_fd.js"
 import { strace } from "./strace.js"
 
-module.exports = {
+export {
     WASI,
     File,
     PreopenDirectory,
     strace,
-}
-
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,6 @@
 import WASI from "./wasi.js"
-import { File } from "./fs_core.js"
-import { PreopenDirectory } from "./fs_fd.js"
-import { strace } from "./strace.js"
+export { WASI };
 
-export {
-    WASI,
-    File,
-    PreopenDirectory,
-    strace,
-};
+export { File } from "./fs_core.js"
+export { PreopenDirectory } from "./fs_fd.js"
+export { strace } from "./strace.js"

--- a/src/wasi.js
+++ b/src/wasi.js
@@ -29,7 +29,7 @@ export default class WASI {
                     buf_size += arg.length + 1;
                 }
                 buffer.setUint32(argv_buf_size, buf_size, true);
-                console.log(buffer.getUint32(argc, true), buffer.getUint32(argv_buf_size, true));
+                //console.log(buffer.getUint32(argc, true), buffer.getUint32(argv_buf_size, true));
                 return 0;
             },
             args_get(argv/*: number*/, argv_buf/*: number*/)/*: number*/ {
@@ -44,7 +44,7 @@ export default class WASI {
                     buffer.setUint8(argv_buf + arg.length, 0);
                     argv_buf += arg.length + 1;
                 }
-                console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_argv_buf, argv_buf)));
+                //console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_argv_buf, argv_buf)));
                 return 0;
             },
 
@@ -56,7 +56,7 @@ export default class WASI {
                     buf_size += environ.length + 1;
                 }
                 buffer.setUint32(environ_size, buf_size, true);
-                console.log(buffer.getUint32(environ_count, true), buffer.getUint32(environ_size, true));
+                //console.log(buffer.getUint32(environ_count, true), buffer.getUint32(environ_size, true));
                 return 0;
             },
             environ_get(environ/*: number*/, environ_buf/*: number*/)/*: number*/ {
@@ -71,7 +71,7 @@ export default class WASI {
                     buffer.setUint8(environ_buf + e.length, 0);
                     environ_buf += e.length + 1;
                 }
-                console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_environ_buf, environ_buf)));
+                //console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_environ_buf, environ_buf)));
                 return 0;
             },
 
@@ -360,7 +360,7 @@ export default class WASI {
                 let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
                 if (self.fds[fd] != undefined) {
                     let path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
-                    console.log(path);
+                    //console.log(path);
                     let { ret, fd_obj } = self.fds[fd].path_open(dirflags, path, oflags, fs_rights_base, fs_rights_inheriting, fd_flags);
                     if (ret != 0) {
                         return ret;
@@ -379,7 +379,7 @@ export default class WASI {
                 let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
                 if (self.fds[fd] != undefined) {
                     let path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
-                    console.log(path);
+                    //console.log(path);
                     let { ret, data } = self.fds[fd].path_readlink(path);
                     if (data != null) {
                         if (data.length > buf_len) {


### PR DESCRIPTION
CommonJS style exports were previously used in index.js despite being an ESM module. Switching to the ESM export syntax fixes webpack.

Fixes #12