### PR TITLE
Add missing export for Fd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import WASI from "./wasi.js";
 export { WASI };
 
+export { Fd } from './fd.js';
 export { File, Directory } from "./fs_core.js";
-export { OpenFile, PreopenDirectory } from "./fs_fd.js";
+export { OpenFile, OpenDirectory, PreopenDirectory } from "./fs_fd.js";
 export { strace } from "./strace.js";


### PR DESCRIPTION
We need to export `Fd` to be able to import it from the package. The export for `OpenDirectory` was also missing.

Apologies for opening yet another PR 😅 