### PR TITLE
Fix types of export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "exports": {
     ".": {
+      "types": "./typings/index.d.ts",
       "import": "./dist/index.js"
     }
   },


### PR DESCRIPTION
This is needed so typescript can find the `d.ts`, given it's not next to the `.js`.