### PR TITLE
BigInt offset typings 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@bjorn3/browser_wasi_shim",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@swc/cli": "^0.1.62",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bjorn3/browser_wasi_shim",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bjorn3/browser_wasi_shim",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "MIT OR Apache-2.0",
   "description": "A pure javascript shim for WASI",
   "type": "module",

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -59,7 +59,7 @@ export class Fd {
   fd_readdir_single(cookie: BigInt) {
     return { ret: -1, dirent: null };
   }
-  fd_seek(offset: number | BigInt, whence) {
+  fd_seek(offset: number | BigInt, whence): { ret: number; offset: number | BigInt } {
     return { ret: -1, offset: 0 };
   }
   fd_sync(): number {

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -59,7 +59,7 @@ export class Fd {
   fd_readdir_single(cookie: BigInt) {
     return { ret: -1, dirent: null };
   }
-  fd_seek(offset: number | BigInt, whence): { ret: number; offset: number | BigInt } {
+  fd_seek(offset: number | BigInt, whence): { ret: number; offset: BigInt } {
     return { ret: -1, offset: 0 };
   }
   fd_sync(): number {

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -2,13 +2,13 @@ import * as wasi from "./wasi_defs.js";
 
 export class Fd {
   fd_advise(
-    offset: number | BigInt,
-    len: BigInt,
-    advice: number | BigInt
+    offset: number | bigint,
+    len: bigint,
+    advice: number | bigint
   ): number {
     return -1;
   }
-  fd_allocate(offset: number | BigInt, len: BigInt): number {
+  fd_allocate(offset: number | bigint, len: bigint): number {
     return -1;
   }
   fd_close(): number {
@@ -24,21 +24,21 @@ export class Fd {
     return -1;
   }
   fd_fdstat_set_rights(
-    fs_rights_base: BigInt,
-    fs_rights_inheriting: BigInt
+    fs_rights_base: bigint,
+    fs_rights_inheriting: bigint
   ): number {
     return -1;
   }
   fd_filestat_get(): { ret: number; filestat: wasi.Filestat | null } {
     return { ret: -1, filestat: null };
   }
-  fd_filestat_set_size(size: number | BigInt): number {
+  fd_filestat_set_size(size: number | bigint): number {
     return -1;
   }
   fd_filestat_set_times(atim, mtim, fst_flags): number {
     return -1;
   }
-  fd_pread(view8: Uint8Array, iovs, offset: number | BigInt) {
+  fd_pread(view8: Uint8Array, iovs, offset: number | bigint) {
     return { ret: -1, nread: 0 };
   }
   fd_prestat_get() {
@@ -47,7 +47,7 @@ export class Fd {
   fd_prestat_dir_name(path_ptr: number, path_len: number) {
     return { ret: -1, prestat_dir_name: null };
   }
-  fd_pwrite(view8: Uint8Array, iovs, offset: number | BigInt) {
+  fd_pwrite(view8: Uint8Array, iovs, offset: number | bigint) {
     return { ret: -1, nwritten: 0 };
   }
   fd_read(
@@ -56,17 +56,17 @@ export class Fd {
   ): { ret: number; nread: number } {
     return { ret: -1, nread: 0 };
   }
-  fd_readdir_single(cookie: BigInt) {
+  fd_readdir_single(cookie: bigint) {
     return { ret: -1, dirent: null };
   }
-  fd_seek(offset: number | BigInt, whence): { ret: number; offset: BigInt } {
+  fd_seek(offset: number | bigint, whence): { ret: number; offset: bigint } {
     return { ret: -1, offset: 0n };
   }
   fd_sync(): number {
     return -1;
   }
-  fd_tell() {
-    return { ret: -1, offset: 0 };
+  fd_tell(): { ret: number; offset: bigint } {
+    return { ret: -1, offset: 0n };
   }
   fd_write(view8, iovs) {
     return { ret: -1, nwritten: 0 };

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -60,7 +60,7 @@ export class Fd {
     return { ret: -1, dirent: null };
   }
   fd_seek(offset: number | BigInt, whence): { ret: number; offset: BigInt } {
-    return { ret: -1, offset: 0 };
+    return { ret: -1, offset: 0n };
   }
   fd_sync(): number {
     return -1;

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -61,16 +61,16 @@ export class OpenFile extends Fd {
         break;
       default:
         // @ts-ignore
-        return { ret: wasi.ERRNO_INVAL, offset: 0 };
+        return { ret: wasi.ERRNO_INVAL, offset: 0n };
     }
 
     if (calculated_offset < 0) {
       // @ts-ignore
-      return { ret: wasi.ERRNO_INVAL, offset: 0 };
+      return { ret: wasi.ERRNO_INVAL, offset: 0n };
     }
 
     this.file_pos = BigInt(calculated_offset);
-    return { ret: 0, offset: calculated_offset };
+    return { ret: 0, offset: this.file_pos };
   }
 
   fd_write(

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -44,7 +44,7 @@ export class OpenFile extends Fd {
     return { ret: 0, nread };
   }
 
-  fd_seek(offset: number | BigInt, whence: number): { ret: number; offset: number | BigInt } {
+  fd_seek(offset: number | BigInt, whence: number): { ret: number; offset: BigInt } {
     let calculated_offset: number;
     switch (whence) {
       case wasi.WHENCE_SET:

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -9,7 +9,7 @@ declare var TextEncoder: {
 
 export class OpenFile extends Fd {
   file: File;
-  file_pos: BigInt = 0n;
+  file_pos: bigint = 0n;
 
   constructor(file: File) {
     super();
@@ -44,7 +44,7 @@ export class OpenFile extends Fd {
     return { ret: 0, nread };
   }
 
-  fd_seek(offset: number | BigInt, whence: number): { ret: number; offset: BigInt } {
+  fd_seek(offset: number | bigint, whence: number): { ret: number; offset: bigint } {
     let calculated_offset: number;
     switch (whence) {
       case wasi.WHENCE_SET:
@@ -117,7 +117,7 @@ export class OpenDirectory extends Fd {
     return { ret: 0, fdstat: new wasi.Fdstat(wasi.FILETYPE_DIRECTORY, 0) };
   }
 
-  fd_readdir_single(cookie: BigInt): {
+  fd_readdir_single(cookie: bigint): {
     ret: number;
     dirent: wasi.Dirent | null;
   } {
@@ -153,8 +153,8 @@ export class OpenDirectory extends Fd {
     dirflags: number,
     path: string,
     oflags: number,
-    fs_rights_base: BigInt,
-    fs_rights_inheriting: BigInt,
+    fs_rights_base: bigint,
+    fs_rights_inheriting: bigint,
     fd_flags: number
   ): { ret: number; fd_obj: Fd | null } {
     let entry = this.dir.get_entry_for_path(path);

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -44,7 +44,7 @@ export class OpenFile extends Fd {
     return { ret: 0, nread };
   }
 
-  fd_seek(offset: number | BigInt, whence: number): { ret: number; offset: number } {
+  fd_seek(offset: number | BigInt, whence: number): { ret: number; offset: number | BigInt } {
     let calculated_offset: number;
     switch (whence) {
       case wasi.WHENCE_SET:

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -373,11 +373,7 @@ export default class WASI {
             offset,
             whence
           );
-          if (typeof offset === 'bigint') {
-            buffer.setBigInt64(offset_out_ptr, offset, true);
-          } else {
-            buffer.setInt32(offset_out_ptr, offset, true);
-          }
+          buffer.setBigInt64(offset_out_ptr, offset, true);
           return ret;
         } else {
           return wasi.ERRNO_BADF;

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -373,7 +373,11 @@ export default class WASI {
             offset,
             whence
           );
-          buffer.setUint32(offset_out_ptr, offset, true);
+          if (typeof offset === 'bigint') {
+            buffer.setBigInt64(offset_out_ptr, offset, true);
+          } else {
+            buffer.setInt32(offset_out_ptr, offset, true);
+          }
           return ret;
         } else {
           return wasi.ERRNO_BADF;
@@ -390,7 +394,7 @@ export default class WASI {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let { ret, offset } = self.fds[fd].fd_tell();
-          buffer.setUint32(offset_ptr, offset, true);
+          buffer.setInt32(offset_ptr, offset, true);
           return ret;
         } else {
           return wasi.ERRNO_BADF;

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -93,7 +93,7 @@ export default class WASI {
       clock_res_get(id: number, res_ptr: number): number {
         throw "unimplemented";
       },
-      clock_time_get(id: number, precision: BigInt, time: number): number {
+      clock_time_get(id: number, precision: bigint, time: number): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         if (id === wasi.CLOCKID_REALTIME) {
           buffer.setBigUint64(
@@ -120,8 +120,8 @@ export default class WASI {
 
       fd_advise(
         fd: number,
-        offset: BigInt,
-        len: BigInt,
+        offset: bigint,
+        len: bigint,
         advice: number
       ): number {
         if (self.fds[fd] != undefined) {
@@ -130,7 +130,7 @@ export default class WASI {
           return wasi.ERRNO_BADF;
         }
       },
-      fd_allocate(fd: number, offset: BigInt, len: BigInt): number {
+      fd_allocate(fd: number, offset: bigint, len: bigint): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_allocate(offset, len);
         } else {
@@ -177,8 +177,8 @@ export default class WASI {
       },
       fd_fdstat_set_rights(
         fd: number,
-        fs_rights_base: BigInt,
-        fs_rights_inheriting: BigInt
+        fs_rights_base: bigint,
+        fs_rights_inheriting: bigint
       ): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_fdstat_set_rights(
@@ -203,7 +203,7 @@ export default class WASI {
           return wasi.ERRNO_BADF;
         }
       },
-      fd_filestat_set_size(fd: number, size: BigInt): number {
+      fd_filestat_set_size(fd: number, size: bigint): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_filestat_set_size(size);
         } else {
@@ -212,8 +212,8 @@ export default class WASI {
       },
       fd_filestat_set_times(
         fd: number,
-        atim: BigInt,
-        mtim: BigInt,
+        atim: bigint,
+        mtim: bigint,
         fst_flags: number
       ): number {
         if (self.fds[fd] != undefined) {
@@ -226,7 +226,7 @@ export default class WASI {
         fd: number,
         iovs_ptr: number,
         iovs_len: number,
-        offset: BigInt,
+        offset: bigint,
         nread_ptr: number
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
@@ -313,7 +313,7 @@ export default class WASI {
         fd: number,
         buf: number,
         buf_len: number,
-        cookie: BigInt,
+        cookie: bigint,
         bufused_ptr: number
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
@@ -373,7 +373,7 @@ export default class WASI {
             offset,
             whence
           );
-          buffer.setBigInt64(offset_out_ptr, offset, true);
+          buffer.setBigInt64(offset_out_ptr, offset_out, true);
           return ret;
         } else {
           return wasi.ERRNO_BADF;
@@ -390,7 +390,7 @@ export default class WASI {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let { ret, offset } = self.fds[fd].fd_tell();
-          buffer.setInt32(offset_ptr, offset, true);
+          buffer.setBigUint64(offset_ptr, offset, true);
           return ret;
         } else {
           return wasi.ERRNO_BADF;

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -184,13 +184,13 @@ declare var TextEncoder: {
 };
 
 export class Dirent {
-  d_next: BigInt;
-  d_ino: BigInt = 1n;
+  d_next: bigint;
+  d_ino: bigint = 1n;
   d_namlen: number;
   d_type: number;
   dir_name: Uint8Array;
 
-  constructor(next_cookie: BigInt, name: string, type: number) {
+  constructor(next_cookie: bigint, name: string, type: number) {
     let encoded_name = new TextEncoder("utf-8").encode(name);
 
     this.d_next = next_cookie;
@@ -230,8 +230,8 @@ export const FDFLAGS_SYNC = 1 << 4;
 export class Fdstat {
   fs_filetype: number;
   fs_flags: number;
-  fs_rights_base: BigInt = 0n;
-  fs_rights_inherited: BigInt = 0n;
+  fs_rights_base: bigint = 0n;
+  fs_rights_inherited: bigint = 0n;
 
   constructor(filetype: number, flags: number) {
     this.fs_filetype = filetype;
@@ -259,16 +259,16 @@ export const OFLAGS_EXCL = 1 << 2;
 export const OFLAGS_TRUNC = 1 << 3;
 
 export class Filestat {
-  dev: BigInt = 0n;
-  ino: BigInt = 0n;
+  dev: bigint = 0n;
+  ino: bigint = 0n;
   filetype: number;
-  nlink: BigInt = 0n;
-  size: BigInt;
-  atim: BigInt = 0n;
-  mtim: BigInt = 0n;
-  ctim: BigInt = 0n;
+  nlink: bigint = 0n;
+  size: bigint;
+  atim: bigint = 0n;
+  mtim: bigint = 0n;
+  ctim: bigint = 0n;
 
-  constructor(filetype: number, size: number | BigInt) {
+  constructor(filetype: number, size: number | bigint) {
     this.filetype = filetype;
     // @ts-ignore
     this.size = BigInt(size);


### PR DESCRIPTION
The field `{offset}` returned from `OpenFile::fd_seek` can be promoted to BigInt. Later on, in `WASI::fd_seek` the call to `buffer.setInt32` fails for BigInt. The proposed patch fixes the problem.