### PR TITLE
Fix rustc example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 typings/
+examples/wasm-rustc

--- a/examples/rustc.html
+++ b/examples/rustc.html
@@ -67,7 +67,7 @@
             new XtermStdio(term),
             new PreopenDirectory("/tmp", {}),
             new PreopenDirectory("/sysroot", {
-                "lib32": new Directory({
+                "lib": new Directory({
                     "rustlib": new Directory({
                         "wasm32-wasi": new Directory({
                             "lib": new Directory({}),

--- a/examples/rustc.html
+++ b/examples/rustc.html
@@ -1,3 +1,9 @@
+<!--
+
+See https://github.com/bjorn3/browser_wasi_shim/pull/28 for instructions on how to use this example.
+
+-->
+
 <!DOCTYPE html>
 <html>
 <head>

--- a/examples/rustc.html
+++ b/examples/rustc.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <div id="terminal"></div>
+<div id="downloads"></div>
 <script type="module">
     import { Fd } from "../dist/fd.js";
     import { File, Directory } from "../dist/fs_core.js";
@@ -50,7 +51,7 @@
 
     (async function () {
         term.writeln("\x1B[93mDownloading\x1B[0m");
-        let wasm = await WebAssembly.compileStreaming(fetch("rustc_binary.wasm"));
+        let wasm = await WebAssembly.compileStreaming(fetch("wasm-rustc/bin/rustc.wasm"));
         //let wasm = await WebAssembly.compileStreaming(fetch("/rust_out.wasm"));
         term.writeln("\x1B[93mInstantiating\x1B[0m");
 
@@ -58,18 +59,15 @@
             return new File(await (await (await fetch(path)).blob()).arrayBuffer());
         }
 
-        let args = ["rustc", "./hello.rs", "--sysroot", "/sysroot", "--target", "x86_64-unknown-linux-gnu", "-Cpanic=abort", "-Ccodegen-units=1"];
-        let env = ["RUSTC_LOG=trace"];
+        let args = ["rustc", "/hello.rs", "--sysroot", "/sysroot", "--target", "x86_64-unknown-linux-gnu", "-Cpanic=abort", "-Ccodegen-units=1"];
+        let env = ["RUSTC_LOG=info"];
         let fds = [
             new XtermStdio(term),
             new XtermStdio(term),
             new XtermStdio(term),
             new PreopenDirectory("/tmp", {}),
-            new PreopenDirectory(".", {
-                "hello.rs": new File(new TextEncoder("utf-8").encode(`fn main() { println!("Hello World!"); }`)),
-            }),
             new PreopenDirectory("/sysroot", {
-                "lib": new Directory({
+                "lib32": new Directory({
                     "rustlib": new Directory({
                         "wasm32-wasi": new Directory({
                             "lib": new Directory({}),
@@ -78,28 +76,45 @@
                             "lib": new Directory(await (async function () {
                                 let dir = {};
                                 for (let file of [
-                                    "libcore-b4a7d25c83ac0d14.rlib",
-                                    "librustc_std_workspace_core-18038143f92ab7ad.rlib",
-                                    "libcompiler_builtins-f0b22b2b55b20afb.rlib",
-                                    "liballoc-072489b01506fb72.rlib",
-                                    "librustc_std_workspace_alloc-eeb0fd7b28eabbfd.rlib",
-                                    "liblibc-f3a5d2870a74e12d.rlib",
-                                    "libunwind-d85e8e3df3b56ff5.rlib",
-                                    "libcfg_if-6b32ca81b3ffdff5.rlib",
-                                    "libbacktrace_sys-93675d780e5d0925.rlib",
-                                    "libbacktrace-30a7c0899d033fc0.rlib",
-                                    "librustc_demangle-92b41332709a8741.rlib",
-                                    "libhashbrown-f92f11aad8210abe.rlib",
-                                    "libstd-358912be09271fe6.rlib",
-                                    "libpanic_abort-9fa38857c2678ded.rlib",
+                                    "libaddr2line-60dea794f80c3ef4.rlib",
+                                    "libadler-d65038594e8cfab3.rlib",
+                                    "liballoc-0de515ba820cdcfa.rlib",
+                                    "libcfg_if-3714295220178beb.rlib",
+                                    "libcompiler_builtins-7deb5fdc76bc68b0.rlib",
+                                    "libcore-1ba018e205a91c17.rlib",
+                                    "libgetopts-f8b396edfb838e11.rlib",
+                                    "libgimli-b7851eb24fb241ab.rlib",
+                                    "libhashbrown-c62361fbb728cc4b.rlib",
+                                    "liblibc-273011445e6504c2.rlib",
+                                    "libmemchr-b587b3bc8d98b4b8.rlib",
+                                    "libminiz_oxide-2d239bf53ecd5d89.rlib",
+                                    "libobject-7b62e7dc54fb7cd7.rlib",
+                                    "libpanic_abort-f0b7506e2ba2830d.rlib",
+                                    "libpanic_unwind-1b641924c3354893.rlib",
+                                    "libproc_macro-e663e39f4c73449c.rlib",
+                                    "librustc_demangle-be7b16a50397ed9c.rlib",
+                                    "librustc_std_workspace_alloc-c0347e439fe1bd8a.rlib",
+                                    "librustc_std_workspace_core-04b73f4c30e9e1dd.rlib",
+                                    "librustc_std_workspace_std-f4bb462fd2254ada.rlib",
+                                    "libstd-21ea728213f8218b.rlib",
+                                    "libstd-21ea728213f8218b.so",
+                                    "libstd_detect-2f7c6cdb3add68c0.rlib",
+                                    "libsysroot-58b33ba40d3a21e1.rlib",
+                                    "libtest-5715830a776353f9.rlib",
+                                    "libtest-5715830a776353f9.so",
+                                    "libunicode_width-5ae0afd9a72d6422.rlib",
+                                    "libunwind-d6ab645e2fcde9a0.rlib",
                                 ]) {
-                                    dir[file] = await load_external_file("/sysroot/lib/rustlib/x86_64-unknown-linux-gnu/lib/" + file);
+                                    dir[file] = await load_external_file("/examples/wasm-rustc/lib/rustlib/x86_64-unknown-linux-gnu/lib/" + file);
                                 }
                                 return dir;
                             })()),
                         }),
                     }),
                 }),
+            }),
+            new PreopenDirectory("/", {
+                "hello.rs": new File(new TextEncoder("utf-8").encode(`fn main() { println!("Hello World!"); }`)),
             }),
         ];
 
@@ -110,13 +125,14 @@
         });
         term.writeln("\x1B[93mExecuting\x1B[0m");
         console.log(inst.exports);
-        w.start(inst);
+        try { w.start(inst); } catch(e) { term.writeln(e); }
         term.writeln("\x1B[92mDone\x1B[0m");
 
-        console.log(fds[4].directory);
-        console.log(fds[4].directory["hello.hello.7rcbfp3g-cgu.0.rcgu.o"].data);
-        document.body.innerHTML += "<br><a href='" + URL.createObjectURL(new Blob([fds[4].directory["hello.hello.7rcbfp3g-cgu.0.rcgu.o"].data], { type: "application/elf" })) + "'>Download object</a>";
-        document.body.innerHTML += "<br><a href='" + URL.createObjectURL(new Blob([fds[4].directory["hello.allocator_shim.rcgu.o"].data], { type: "application/elf" })) + "'>Download allocator shim</a>";
+        console.log(fds);
+        console.log(fds[5].dir);
+        console.log(fds[5].dir.contents["hello.hello.7631c747841c2a99-cgu.0.rcgu.o"].data);
+        document.querySelector("#downloads").innerHTML += "<br><a href='" + URL.createObjectURL(new Blob([fds[5].dir.contents["hello.hello.7631c747841c2a99-cgu.0.rcgu.o"].data], { type: "application/elf" })) + "'>Download object</a>";
+        document.querySelector("#downloads").innerHTML += "<br><a href='" + URL.createObjectURL(new Blob([fds[5].dir.contents["hello.allocator_shim.rcgu.o"].data], { type: "application/elf" })) + "'>Download allocator shim</a>";
     })();
 </script>
 </body>

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -12,7 +12,7 @@ export class Fd {
     return -1;
   }
   fd_close(): number {
-    return -1;
+    return 0;
   }
   fd_datasync(): number {
     return -1;
@@ -56,7 +56,10 @@ export class Fd {
   ): { ret: number; nread: number } {
     return { ret: -1, nread: 0 };
   }
-  fd_readdir_single(cookie: bigint) {
+  fd_readdir_single(cookie: bigint): {
+    ret: number;
+    dirent: wasi.Dirent | null;
+  } {
     return { ret: -1, dirent: null };
   }
   fd_seek(offset: bigint, whence: number): { ret: number; offset: bigint } {

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -36,17 +36,20 @@ export class Directory {
     let entry: File | Directory = this;
     for (let component of path.split("/")) {
       if (component == "") break;
-      if (this.contents[component] != undefined) {
-        entry = this.contents[component];
+      if (!(entry instanceof Directory)) {
+        return null;
+      }
+      if (entry.contents[component] != undefined) {
+        entry = entry.contents[component];
       } else {
-        //console.log(component);
+        console.log(component);
         return null;
       }
     }
     return entry;
   }
 
-  create_entry_for_path(path: string): File | Directory {
+  create_entry_for_path(path: string, is_dir: boolean): File | Directory {
     // FIXME fix type errors
     let entry: File | Directory = this;
     let components: Array<string> = path
@@ -60,7 +63,7 @@ export class Directory {
         entry = entry.contents[component];
       } else {
         //console.log("create", component);
-        if (i == components.length - 1) {
+        if ((i == components.length - 1) && !is_dir) {
           // @ts-ignore
           entry.contents[component] = new File(new ArrayBuffer(0));
         } else {

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -157,7 +157,7 @@ export class OpenDirectory extends Fd {
     let entry = this.dir.get_entry_for_path(path);
     if (entry == null) {
       if ((oflags & wasi.OFLAGS_CREAT) == wasi.OFLAGS_CREAT) {
-        entry = this.dir.create_entry_for_path(path);
+        entry = this.dir.create_entry_for_path(path, (oflags & wasi.OFLAGS_DIRECTORY) == wasi.OFLAGS_DIRECTORY);
       } else {
         return { ret: -1, fd_obj: null };
       }
@@ -183,6 +183,10 @@ export class OpenDirectory extends Fd {
     } else {
       throw "dir entry neither file nor dir";
     }
+  }
+
+  path_create_directory(path: string): number {
+    return this.path_open(0, path, wasi.OFLAGS_CREAT | wasi.OFLAGS_DIRECTORY, 0n, 0n, 0).ret;
   }
 }
 

--- a/src/strace.ts
+++ b/src/strace.ts
@@ -2,13 +2,15 @@
 export function strace<T extends object>(imports: T, no_trace: Array<string|symbol>) {
   return new Proxy(imports, {
     get(target, prop, receiver) {
-      let res = Reflect.get(target, prop, receiver);
+      let f = Reflect.get(target, prop, receiver);
       if (no_trace.includes(prop)) {
-        return res;
+        return f;
       }
       return function (...args) {
         console.log(prop, "(", ...args, ")");
-        return Reflect.apply(res as Function, receiver, args);
+        let result = Reflect.apply(f as Function, receiver, args);
+        console.log(" =", result);
+        return result;
       };
     },
   });

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -330,15 +330,30 @@ export default class WASI {
             if (dirent == null) {
               break;
             }
-            let offset = dirent.length();
 
-            if (buf_len - bufused < offset) {
+            if (buf_len - bufused < dirent.head_length()) {
+              bufused = buf_len;
               break;
             }
 
-            dirent.write_bytes(buffer, buffer8, buf);
-            buf += offset;
-            bufused += offset;
+            let head_bytes = new ArrayBuffer(dirent.head_length());
+            dirent.write_head_bytes(new DataView(head_bytes), 0);
+            buffer8.set(
+              (new Uint8Array(head_bytes)).slice(0, Math.min(head_bytes.byteLength, buf_len - bufused)),
+              buf,
+            );
+            buf += dirent.head_length();
+            bufused += dirent.head_length();
+
+            if (buf_len - bufused < dirent.name_length()) {
+              bufused = buf_len;
+              break;
+            }
+
+            dirent.write_name_bytes(buffer8, buf, buf_len - bufused);
+            buf += dirent.name_length();
+            bufused += dirent.name_length();
+
             cookie = dirent.d_next;
           }
 

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -199,18 +199,25 @@ export class Dirent {
     this.dir_name = encoded_name;
   }
 
-  length(): number {
-    return 24 + this.dir_name.byteLength;
+  head_length(): number {
+    return 24;
   }
 
-  write_bytes(view: DataView, view8: Uint8Array, ptr: number) {
+  name_length(): number {
+    return this.dir_name.byteLength;
+  }
+
+  write_head_bytes(view: DataView, ptr: number) {
     // @ts-ignore
     view.setBigUint64(ptr, this.d_next, true);
     // @ts-ignore
     view.setBigUint64(ptr + 8, this.d_ino, true);
     view.setUint32(ptr + 16, this.dir_name.length, true); // d_namlen
     view.setUint8(ptr + 20, this.d_type);
-    view8.set(this.dir_name, ptr + 24);
+  }
+
+  write_name_bytes(view8: Uint8Array, ptr: number, buf_len: number) {
+    view8.set(this.dir_name.slice(0, Math.min(this.dir_name.byteLength, buf_len)), ptr);
   }
 }
 


### PR DESCRIPTION
You can download the precompiled rustc binary from https://github.com/rust-lang/miri/issues/722#issuecomment-1584287506. You will need to unpack the contained `dist` directory as `examples/wasm-rustc`.