### PR TITLE
Misc fixes

### DIFF
--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -36,6 +36,7 @@ export class Directory {
     let entry: File | Directory = this;
     for (let component of path.split("/")) {
       if (component == "") break;
+      if (component == ".") continue;
       if (!(entry instanceof Directory)) {
         return null;
       }

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -141,7 +141,7 @@ export class OpenDirectory extends Fd {
   ): { ret: number; filestat: wasi.Filestat | null } {
     let entry = this.dir.get_entry_for_path(path);
     if (entry == null) {
-      return { ret: -1, filestat: null };
+      return { ret: wasi.ERRNO_EXIST, filestat: null };
     }
     return { ret: 0, filestat: entry.stat() };
   }


### PR DESCRIPTION
* Handle `.` components in paths.
* Return EEXIST on non-existent files in path_filestat_get.

The first fix is required to run esbuild compiled to wasm: https://fosstodon.org/@jakebailey/110182326132563028 The second one improves error messages presented by guest programs.