### PR TITLE
Add support for files in OPFS

### DIFF
--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -9,8 +9,10 @@ export class File {
     this.data = new Uint8Array(data);
   }
 
-  open() {
-    return new OpenFile(this);
+  open(fd_flags: number) {
+    let file = new OpenFile(this);
+    if (fd_flags & wasi.FDFLAGS_APPEND) file.fd_seek(0n, wasi.WHENCE_END);
+    return file;
   }
 
   get size(): bigint {
@@ -37,10 +39,13 @@ export interface FileSystemSyncAccessHandle {
 }
 
 export class SyncOPFSFile {
+  // FIXME needs a close() method to be called after start() to release the underlying handle
   constructor(public handle: FileSystemSyncAccessHandle) { }
 
-  open() {
-    return new OpenSyncOPFSFile(this);
+  open(fd_flags: number) {
+    let file = new OpenSyncOPFSFile(this);
+    if (fd_flags & wasi.FDFLAGS_APPEND) file.fd_seek(0n, wasi.WHENCE_END);
+    return file;
   }
 
   get size(): bigint {
@@ -64,7 +69,7 @@ export class Directory {
     this.contents = contents;
   }
 
-  open() {
+  open(fd_flags: number) {
     return new OpenDirectory(this);
   }
 

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -1,3 +1,4 @@
+import { OpenDirectory, OpenFile, OpenSyncOPFSFile } from "./fs_fd.js";
 import * as wasi from "./wasi_defs.js";
 
 export class File {
@@ -6,6 +7,10 @@ export class File {
   constructor(data: ArrayBuffer | Uint8Array | Array<number>) {
     //console.log(data);
     this.data = new Uint8Array(data);
+  }
+
+  open() {
+    return new OpenFile(this);
   }
 
   get size(): bigint {
@@ -34,6 +39,10 @@ export interface FileSystemSyncAccessHandle {
 export class SyncOPFSFile {
   constructor(public handle: FileSystemSyncAccessHandle) { }
 
+  open() {
+    return new OpenSyncOPFSFile(this);
+  }
+
   get size(): bigint {
     return BigInt(this.handle.getSize());
   }
@@ -53,6 +62,10 @@ export class Directory {
 
   constructor(contents: { [key: string]: File | Directory | SyncOPFSFile }) {
     this.contents = contents;
+  }
+
+  open() {
+    return new OpenDirectory(this);
   }
 
   stat(): wasi.Filestat {

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -31,11 +31,11 @@ export class File {
 // Shim for https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle
 // This is not part of the public interface.
 export interface FileSystemSyncAccessHandle {
-  close(): undefined;
-  flush(): undefined;
+  close(): void;
+  flush(): void;
   getSize(): number;
   read(buffer: ArrayBuffer | ArrayBufferView, options?: { at: number }): number;
-  truncate(to: number): undefined;
+  truncate(to: number): void;
   write(buffer: ArrayBuffer | ArrayBufferView, options?: { at: number }): number;
 }
 

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -28,7 +28,8 @@ export class File {
   }
 }
 
-// shim https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle
+// Shim for https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle
+// This is not part of the public interface.
 export interface FileSystemSyncAccessHandle {
   close(): undefined;
   flush(): undefined;

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -39,6 +39,8 @@ export interface FileSystemSyncAccessHandle {
   write(buffer: ArrayBuffer | ArrayBufferView, options?: { at: number }): number;
 }
 
+// Synchronous access to an individual file in the origin private file system.
+// Only allowed inside a WebWorker.
 export class SyncOPFSFile {
   // FIXME needs a close() method to be called after start() to release the underlying handle
   constructor(public handle: FileSystemSyncAccessHandle) { }

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -258,17 +258,7 @@ export class OpenDirectory extends Fd {
       // @ts-ignore
       entry.truncate();
     }
-    // FIXME handle this more elegantly
-    if (entry instanceof File) {
-      // @ts-ignore
-      return { ret: 0, fd_obj: new OpenFile(entry) };
-    } else if (entry instanceof SyncOPFSFile) {
-      return { ret: 0, fd_obj: new OpenSyncOPFSFile(entry) }
-    } else if (entry instanceof Directory) {
-      return { ret: 0, fd_obj: new OpenDirectory(entry) };
-    } else {
-      throw "dir entry neither file nor dir";
-    }
+    return { ret: 0, fd_obj: entry.open() };
   }
 
   path_create_directory(path: string): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import WASI from "./wasi.js";
 export { WASI };
 
 export { Fd } from './fd.js';
-export { File, Directory } from "./fs_core.js";
-export { OpenFile, OpenDirectory, PreopenDirectory } from "./fs_fd.js";
+export { File, SyncOPFSFile as OPFSFile, Directory } from "./fs_core.js";
+export { OpenFile, OpenDirectory, OpenSyncOPFSFile as OpenOPFSFile, PreopenDirectory } from "./fs_fd.js";
 export { strace } from "./strace.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@ export { WASI };
 
 export { Fd } from './fd.js';
 export { File, SyncOPFSFile as OPFSFile, Directory } from "./fs_core.js";
-export { OpenFile, OpenDirectory, OpenSyncOPFSFile as OpenOPFSFile, PreopenDirectory } from "./fs_fd.js";
+export { OpenFile, OpenDirectory, OpenSyncOPFSFile, PreopenDirectory } from "./fs_fd.js";
 export { strace } from "./strace.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import WASI from "./wasi.js";
 export { WASI };
 
 export { Fd } from './fd.js';
-export { File, SyncOPFSFile as OPFSFile, Directory } from "./fs_core.js";
+export { File, SyncOPFSFile, Directory } from "./fs_core.js";
 export { OpenFile, OpenDirectory, OpenSyncOPFSFile, PreopenDirectory } from "./fs_fd.js";
 export { strace } from "./strace.js";

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -18,6 +18,7 @@ export default class WASI {
 
   /// Start a WASI command
   start(instance: {
+    // FIXME v0.3: close opened Fds after execution
     exports: { memory: WebAssembly.Memory; _start: () => mixed };
   }) {
     this.inst = instance;


### PR DESCRIPTION
This could partly fix #32 by allowing to use [`FileSystemSyncAccessHandle`s](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle) in Workers for single files opened from [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system) as [noted in my last comment](https://github.com/bjorn3/browser_wasi_shim/issues/32#issuecomment-1612637810). Usage example:

```ts
// open synchronous handle to a file in opfs
const opfs = await navigator.storage.getDirectory();
const file = await opfs.getFileHandle("example.txt");
const handle = await file.createSyncAccessHandle();

// populate the virtual filesystem for shim
const fds: Array<Fd> = [
  new OpenFile(new File([])), // stdin
  new OpenFile(new File([])), // stdout
  new OpenFile(new File([])), // stderr
  new PreopenDirectory("/", {
    "example.txt": new OPFSFile(handle),
  }),
];
const shim = new WASI(args, envs, fds);
```

~~**This should currently be considered *very* WIP, as I've developed this out-of-tree in my project and then tried to copy it into this fork. That means I haven't actually run the code here yet.**~~ In my project I could successfully read a small file though: 
![image](https://github.com/bjorn3/browser_wasi_shim/assets/11139925/978477d4-5c1d-4760-b9c8-abf354eefcef)
