### PR TITLE
Add readonly flag to Files

### DIFF
--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -1,12 +1,18 @@
 import { OpenDirectory, OpenFile, OpenSyncOPFSFile } from "./fs_fd.js";
 import * as wasi from "./wasi_defs.js";
 
+// options that can be passed to Files and SyncOPFSFiles
+type FileOptions = Partial<{
+  readonly: boolean;
+}>;
+
 export class File {
   data: Uint8Array;
+  readonly: boolean;
 
-  constructor(data: ArrayBuffer | Uint8Array | Array<number>) {
-    //console.log(data);
+  constructor(data: ArrayBuffer | SharedArrayBuffer | Uint8Array | Array<number>, options?: FileOptions) {
     this.data = new Uint8Array(data);
+    this.readonly = !!options?.readonly;
   }
 
   open(fd_flags: number) {
@@ -24,6 +30,7 @@ export class File {
   }
 
   truncate() {
+    if (this.readonly) throw "readonly file!";
     this.data = new Uint8Array([]);
   }
 }
@@ -42,8 +49,14 @@ export interface FileSystemSyncAccessHandle {
 // Synchronous access to an individual file in the origin private file system.
 // Only allowed inside a WebWorker.
 export class SyncOPFSFile {
+  handle: FileSystemSyncAccessHandle;
+  readonly: boolean;
+
   // FIXME needs a close() method to be called after start() to release the underlying handle
-  constructor(public handle: FileSystemSyncAccessHandle) { }
+  constructor(handle: FileSystemSyncAccessHandle, options?: FileOptions) {
+    this.handle = handle;
+    this.readonly = !!options?.readonly;
+  }
 
   open(fd_flags: number) {
     let file = new OpenSyncOPFSFile(this);
@@ -60,6 +73,7 @@ export class SyncOPFSFile {
   }
 
   truncate() {
+    if (this.readonly) throw "readonly file!";
     return this.handle.truncate(0);
   }
 
@@ -67,6 +81,7 @@ export class SyncOPFSFile {
 
 export class Directory {
   contents: { [key: string]: File | Directory | SyncOPFSFile };
+  readonly = false; // FIXME implement, like marking all files within readonly?
 
   constructor(contents: { [key: string]: File | Directory | SyncOPFSFile }) {
     this.contents = contents;

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -29,9 +29,10 @@ export class File {
     return new wasi.Filestat(wasi.FILETYPE_REGULAR_FILE, this.size);
   }
 
-  truncate() {
-    if (this.readonly) throw "readonly file!";
+  truncate(): number {
+    if (this.readonly) return wasi.ERRNO_PERM;
     this.data = new Uint8Array([]);
+    return wasi.ERRNO_SUCCESS;
   }
 }
 
@@ -72,9 +73,10 @@ export class SyncOPFSFile {
     return new wasi.Filestat(wasi.FILETYPE_REGULAR_FILE, this.size);
   }
 
-  truncate() {
-    if (this.readonly) throw "readonly file!";
-    return this.handle.truncate(0);
+  truncate(): number {
+    if (this.readonly) return wasi.ERRNO_PERM;
+    this.handle.truncate(0);
+    return wasi.ERRNO_SUCCESS;
   }
 
 }

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -258,9 +258,13 @@ export class OpenDirectory extends Fd {
     ) {
       return { ret: wasi.ERRNO_PERM, fd_obj: null };
     }
-    if ((oflags & wasi.OFLAGS_TRUNC) == wasi.OFLAGS_TRUNC) {
-      // @ts-ignore
-      entry.truncate();
+    if (
+      (!(entry instanceof Directory)) &&
+      (oflags & wasi.OFLAGS_TRUNC) == wasi.OFLAGS_TRUNC
+    ) {
+      let ret = entry.truncate();
+      if (ret != wasi.ERRNO_SUCCESS)
+        return { ret, fd_obj: null };
     }
     return { ret: 0, fd_obj: entry.open(fd_flags) };
   }

--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -78,7 +78,7 @@ export class OpenFile extends Fd {
     iovs: Array<wasi.Ciovec>
   ): { ret: number; nwritten: number } {
     let nwritten = 0;
-    if (this.file.readonly) return { ret: wasi.ERRNO_ROFS, nwritten };
+    if (this.file.readonly) return { ret: wasi.ERRNO_BADF, nwritten };
     for (let iovec of iovs) {
       let buffer = view8.slice(iovec.buf, iovec.buf + iovec.buf_len);
       if (this.file_pos + BigInt(buffer.byteLength) > this.file.size) {
@@ -159,7 +159,7 @@ export class OpenSyncOPFSFile extends Fd {
 
   fd_write(view8: Uint8Array, iovs: Array<wasi.Iovec>): { ret: number, nwritten: number } {
     let nwritten = 0;
-    if (this.file.readonly) return { ret: wasi.ERRNO_ROFS, nwritten };
+    if (this.file.readonly) return { ret: wasi.ERRNO_BADF, nwritten };
     for (let iovec of iovs) {
       let buf = new Uint8Array(view8.buffer, iovec.buf, iovec.buf_len);
       // don't need to extend file manually, just write


### PR DESCRIPTION
This PR adds an `options?: FileOptions` argument to `File` and `SyncOPFSFile`, where the only known option so far is a `readonly` boolean. This is then handled in `truncate()`, `fd_write()` and `path_open()`.

A usage example might be safely sharing a data file amongst multiple instances—or even Workers—by backing a `File` with a `SharedArrayBuffer` and marking it "readonly".