### PR TITLE
shim sock_accept

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -664,6 +664,9 @@ export default class WASI {
       sock_shutdown(fd: number, how) {
         throw "sockets not supported";
       },
+      sock_accept(fd: number, flags) {
+        throw "sockets not supported";
+      },
     };
   }
 }


### PR DESCRIPTION
It just needs to *exist* in the imports for some binaries, even if they don't actually use it. For example the [Python interpreter](https://github.com/vmware-labs/webassembly-language-runtimes/releases/tag/python%2F3.11.4%2B20230714-11be424) requires this.

See #37 for more context.