### PR TITLE
Made project more accessible to contributions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  rules: {
+    "@typescript-eslint/no-this-alias": "off",
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 dist/
 typings/
-examples/wasm-rustc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/wasm-rustc"]
+	path = examples/wasm-rustc
+	url = git@github.com:bjorn3/wasm-rustc.git

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "printWidth": 80
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ let inst = await WebAssembly.instantiate(wasm, {
 wasi.start(inst);
 ```
 
+## Building
+
+```
+$ npm install
+$ npm run build
+```
+
+## Running the demo
+
+The demo requires the wasm rustc artifacts and the xterm js package. To get them run:
+
+```
+$ git submodule update --init
+$ cd examples && npm install
+```
+
+Run the demo with a static web server from the root of this project:
+
+```
+$ npx http-server
+```
+
+And visit [http://127.0.0.1:8080/examples/rustc.html]() in your browser.
+
 ## License
 
 Licensed under either of

--- a/examples/rustc.html
+++ b/examples/rustc.html
@@ -20,12 +20,16 @@ See https://github.com/bjorn3/browser_wasi_shim/pull/28 for instructions on how 
 <body>
 <div id="terminal"></div>
 <div id="downloads"></div>
+<p id="note">
+  Note: the panic at the end is expected. This demo highlights how far `rustc` can get on this polyfill before failing due to other reasons.
+</p>
 <script type="module">
     import { Fd } from "../dist/fd.js";
     import { File, Directory } from "../dist/fs_core.js";
     import { PreopenDirectory } from "../dist/fs_fd.js";
-    import WASI from "../dist/wasi.js";
+    import { WASI } from "../dist/index.js";
     import { strace } from "../dist/strace.js"
+
 
     var term = new Terminal({
         convertEol: true,
@@ -124,7 +128,7 @@ See https://github.com/bjorn3/browser_wasi_shim/pull/28 for instructions on how 
             }),
         ];
 
-        let w = new WASI(args, env, fds);
+        let w = new WASI(args, env, fds, { debug: true });
 
         let inst = await WebAssembly.instantiate(wasm, {
             "wasi_snapshot_preview1": strace(w.wasiImport, ["fd_prestat_get"]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@swc/cli": "^0.1.62",
         "@swc/core": "^1.3.37",
+        "prettier": "^3.0.3",
         "typescript": "^4.9.5"
       }
     },
@@ -1211,6 +1212,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pseudomap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,110 @@
       "devDependencies": {
         "@swc/cli": "^0.1.62",
         "@swc/core": "^1.3.37",
+        "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@typescript-eslint/parser": "^6.7.4",
+        "eslint": "^8.50.0",
         "prettier": "^3.0.3",
         "typescript": "^4.9.5"
       }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
+      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "node_modules/@mole-inc/bin-wrapper": {
       "version": "8.0.1",
@@ -334,6 +435,12 @@
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "dev": true
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -358,6 +465,262 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
+      "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/type-utils": "6.7.4",
+        "@typescript-eslint/utils": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
+      "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
+      "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
+      "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/utils": "6.7.4",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
+      "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.7.4",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
+      "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -377,6 +740,27 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/bin-check": {
       "version": "4.1.0",
@@ -542,6 +926,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -596,6 +990,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -608,6 +1027,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -616,6 +1053,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -638,6 +1081,23 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -667,6 +1127,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -674,6 +1140,30 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -695,6 +1185,230 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.50.0",
+        "@humanwhocodes/config-array": "^0.11.11",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -752,6 +1466,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -768,6 +1488,18 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -775,6 +1507,18 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/file-type": {
@@ -835,6 +1579,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-versions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
@@ -850,6 +1610,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
     "node_modules/get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -857,6 +1643,26 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -869,6 +1675,41 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/got": {
@@ -894,6 +1735,21 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -944,6 +1800,50 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -980,6 +1880,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -1004,20 +1913,78 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -1093,6 +2060,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -1141,6 +2132,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/os-filter-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
@@ -1171,6 +2179,66 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -1178,6 +2246,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/peek-readable": {
@@ -1214,6 +2291,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
@@ -1243,6 +2329,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -1313,6 +2408,15 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
@@ -1333,6 +2437,21 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -1379,9 +2498,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1522,6 +2641,18 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -1538,6 +2669,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-outer": {
@@ -1568,6 +2711,24 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1610,6 +2771,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1621,6 +2818,15 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -1652,6 +2858,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "swc src -d dist && tsc --emitDeclarationOnly",
     "prepare": "swc src -d dist && tsc --emitDeclarationOnly",
-    "check": "tsc --noEmit && prettier src -c"
+    "check": "tsc --noEmit && prettier src -c && eslint src/"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,9 @@
   "devDependencies": {
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.37",
+    "@typescript-eslint/eslint-plugin": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.4",
+    "eslint": "^8.50.0",
     "prettier": "^3.0.3",
     "typescript": "^4.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "swc src -d dist && tsc --emitDeclarationOnly",
     "prepare": "swc src -d dist && tsc --emitDeclarationOnly",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit && prettier src -c"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.37",
+    "prettier": "^3.0.3",
     "typescript": "^4.9.5"
   }
 }

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,34 @@
+class Debug {
+  prefix?: string = "wasi:";
+  log: (...unknown) => void;
+
+  constructor(private isEnabled: boolean) {
+    this.enable(isEnabled);
+  }
+
+  // Recreate the logger function with the new enabled state.
+  enable(enabled?: boolean) {
+    this.log = createLogger(
+      enabled === undefined ? true : enabled,
+      this.prefix,
+    );
+  }
+
+  // Getter for the private isEnabled property.
+  get enabled(): boolean {
+    return this.isEnabled;
+  }
+}
+
+// The createLogger() creates either an empty function or a bound console.log
+// function so we can retain accurate line lumbers on Debug.log() calls.
+function createLogger(enabled: boolean, prefix?: string): (...unknown) => void {
+  if (enabled) {
+    const a = console.log.bind(console, "%c%s", "color: #265BA0", prefix);
+    return a;
+  } else {
+    return () => {};
+  }
+}
+
+export const debug = new Debug(false);

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -1,11 +1,7 @@
 import * as wasi from "./wasi_defs.js";
 
 export class Fd {
-  fd_advise(
-    offset: bigint,
-    len: bigint,
-    advice: number
-  ): number {
+  fd_advise(offset: bigint, len: bigint, advice: number): number {
     return -1;
   }
   fd_allocate(offset: bigint, len: bigint): number {
@@ -25,7 +21,7 @@ export class Fd {
   }
   fd_fdstat_set_rights(
     fs_rights_base: bigint,
-    fs_rights_inheriting: bigint
+    fs_rights_inheriting: bigint,
   ): number {
     return -1;
   }
@@ -52,7 +48,7 @@ export class Fd {
   }
   fd_read(
     view8: Uint8Array,
-    iovs: Array<wasi.Iovec>
+    iovs: Array<wasi.Iovec>,
   ): { ret: number; nread: number } {
     return { ret: -1, nread: 0 };
   }
@@ -92,7 +88,7 @@ export class Fd {
     oflags,
     fs_rights_base,
     fs_rights_inheriting,
-    fdflags
+    fdflags,
   ) {
     return { ret: -1, fd_obj: null };
   }

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-unused-vars:0 */
 import * as wasi from "./wasi_defs.js";
 
 export class Fd {
@@ -40,7 +41,7 @@ export class Fd {
   fd_prestat_get() {
     return { ret: -1, prestat: null };
   }
-  fd_prestat_dir_name(path_ptr: number, path_len: number) {
+  fd_prestat_dir_name() {
     return { ret: -1, prestat_dir_name: null };
   }
   fd_pwrite(view8: Uint8Array, iovs: Array<wasi.Ciovec>, offset: bigint) {

--- a/src/fs_core.ts
+++ b/src/fs_core.ts
@@ -10,7 +10,10 @@ export class File {
   data: Uint8Array;
   readonly: boolean;
 
-  constructor(data: ArrayBuffer | SharedArrayBuffer | Uint8Array | Array<number>, options?: FileOptions) {
+  constructor(
+    data: ArrayBuffer | SharedArrayBuffer | Uint8Array | Array<number>,
+    options?: FileOptions,
+  ) {
     this.data = new Uint8Array(data);
     this.readonly = !!options?.readonly;
   }
@@ -44,7 +47,10 @@ export interface FileSystemSyncAccessHandle {
   getSize(): number;
   read(buffer: ArrayBuffer | ArrayBufferView, options?: { at: number }): number;
   truncate(to: number): void;
-  write(buffer: ArrayBuffer | ArrayBufferView, options?: { at: number }): number;
+  write(
+    buffer: ArrayBuffer | ArrayBufferView,
+    options?: { at: number },
+  ): number;
 }
 
 // Synchronous access to an individual file in the origin private file system.
@@ -78,7 +84,6 @@ export class SyncOPFSFile {
     this.handle.truncate(0);
     return wasi.ERRNO_SUCCESS;
   }
-
 }
 
 export class Directory {
@@ -129,7 +134,7 @@ export class Directory {
         entry = entry.contents[component];
       } else {
         //console.log("create", component);
-        if ((i == components.length - 1) && !is_dir) {
+        if (i == components.length - 1 && !is_dir) {
           // @ts-ignore
           entry.contents[component] = new File(new ArrayBuffer(0));
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import WASI from "./wasi.js";
 export { WASI };
 
-export { Fd } from './fd.js';
+export { Fd } from "./fd.js";
 export { File, SyncOPFSFile, Directory } from "./fs_core.js";
-export { OpenFile, OpenDirectory, OpenSyncOPFSFile, PreopenDirectory } from "./fs_fd.js";
+export {
+  OpenFile,
+  OpenDirectory,
+  OpenSyncOPFSFile,
+  PreopenDirectory,
+} from "./fs_fd.js";
 export { strace } from "./strace.js";

--- a/src/strace.ts
+++ b/src/strace.ts
@@ -4,13 +4,14 @@ export function strace<T extends object>(
 ) {
   return new Proxy(imports, {
     get(target, prop, receiver) {
-      let f = Reflect.get(target, prop, receiver);
+      const f = Reflect.get(target, prop, receiver);
       if (no_trace.includes(prop)) {
         return f;
       }
       return function (...args) {
         console.log(prop, "(", ...args, ")");
-        let result = Reflect.apply(f as Function, receiver, args);
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        const result = Reflect.apply(f as Function, receiver, args);
         console.log(" =", result);
         return result;
       };

--- a/src/strace.ts
+++ b/src/strace.ts
@@ -1,5 +1,7 @@
-
-export function strace<T extends object>(imports: T, no_trace: Array<string|symbol>) {
+export function strace<T extends object>(
+  imports: T,
+  no_trace: Array<string | symbol>,
+) {
   return new Proxy(imports, {
     get(target, prop, receiver) {
       let f = Reflect.get(target, prop, receiver);

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -1,25 +1,22 @@
 import * as wasi from "./wasi_defs.js";
 import { Fd } from "./fd.js";
+import { debug } from "./debug.js";
 
-type mixed = any;
-
-declare var TextEncoder: {
-  prototype: TextEncoder;
-  new (encoding?: string): TextEncoder;
-};
+export interface Options {
+  debug?: boolean;
+}
 
 export default class WASI {
   args: Array<string> = [];
   env: Array<string> = [];
   fds: Array<Fd> = [];
-  //@ts-ignore
   inst: { exports: { memory: WebAssembly.Memory } };
-  wasiImport: { [key: string]: (...args: Array<any>) => mixed };
+  wasiImport: { [key: string]: (...args: Array<unknown>) => unknown };
 
   /// Start a WASI command
   start(instance: {
     // FIXME v0.3: close opened Fds after execution
-    exports: { memory: WebAssembly.Memory; _start: () => mixed };
+    exports: { memory: WebAssembly.Memory; _start: () => unknown };
   }) {
     this.inst = instance;
     instance.exports._start();
@@ -27,77 +24,103 @@ export default class WASI {
 
   /// Initialize a WASI reactor
   initialize(instance: {
-    exports: { memory: WebAssembly.Memory; _initialize: () => mixed };
+    exports: { memory: WebAssembly.Memory; _initialize: () => unknown };
   }) {
     this.inst = instance;
     instance.exports._initialize();
   }
 
-  constructor(args: Array<string>, env: Array<string>, fds: Array<Fd>) {
+  constructor(
+    args: Array<string>,
+    env: Array<string>,
+    fds: Array<Fd>,
+    options: Options = {},
+  ) {
+    debug.enable(options.debug);
+
     this.args = args;
     this.env = env;
     this.fds = fds;
-    let self = this;
+    const self = this;
     this.wasiImport = {
       args_sizes_get(argc: number, argv_buf_size: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         buffer.setUint32(argc, self.args.length, true);
         let buf_size = 0;
-        for (let arg of self.args) {
+        for (const arg of self.args) {
           buf_size += arg.length + 1;
         }
         buffer.setUint32(argv_buf_size, buf_size, true);
-        //console.log(buffer.getUint32(argc, true), buffer.getUint32(argv_buf_size, true));
+        debug.log(
+          buffer.getUint32(argc, true),
+          buffer.getUint32(argv_buf_size, true),
+        );
         return 0;
       },
       args_get(argv: number, argv_buf: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
-        let orig_argv_buf = argv_buf;
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const orig_argv_buf = argv_buf;
         for (let i = 0; i < self.args.length; i++) {
           buffer.setUint32(argv, argv_buf, true);
           argv += 4;
-          let arg = new TextEncoder("utf-8").encode(self.args[i]);
+          const arg = new TextEncoder().encode(self.args[i]);
           buffer8.set(arg, argv_buf);
           buffer.setUint8(argv_buf + arg.length, 0);
           argv_buf += arg.length + 1;
         }
-        //console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_argv_buf, argv_buf)));
+        if (debug.enabled) {
+          debug.log(
+            new TextDecoder("utf-8").decode(
+              buffer8.slice(orig_argv_buf, argv_buf),
+            ),
+          );
+        }
         return 0;
       },
 
       environ_sizes_get(environ_count: number, environ_size: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         buffer.setUint32(environ_count, self.env.length, true);
         let buf_size = 0;
-        for (let environ of self.env) {
+        for (const environ of self.env) {
           buf_size += environ.length + 1;
         }
         buffer.setUint32(environ_size, buf_size, true);
-        //console.log(buffer.getUint32(environ_count, true), buffer.getUint32(environ_size, true));
+        debug.log(
+          buffer.getUint32(environ_count, true),
+          buffer.getUint32(environ_size, true),
+        );
         return 0;
       },
       environ_get(environ: number, environ_buf: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
-        let orig_environ_buf = environ_buf;
-        for (let i = 0; i < env.length; i++) {
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const orig_environ_buf = environ_buf;
+        for (let i = 0; i < self.env.length; i++) {
           buffer.setUint32(environ, environ_buf, true);
           environ += 4;
-          let e = new TextEncoder("utf-8").encode(env[i]);
+          const e = new TextEncoder().encode(self.env[i]);
           buffer8.set(e, environ_buf);
           buffer.setUint8(environ_buf + e.length, 0);
           environ_buf += e.length + 1;
         }
-        //console.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_environ_buf, environ_buf)));
+        if (debug.enabled) {
+          debug.log(
+            new TextDecoder("utf-8").decode(
+              buffer8.slice(orig_environ_buf, environ_buf),
+            ),
+          );
+        }
         return 0;
       },
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       clock_res_get(id: number, res_ptr: number): number {
         throw "unimplemented";
       },
       clock_time_get(id: number, precision: bigint, time: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         if (id === wasi.CLOCKID_REALTIME) {
           buffer.setBigUint64(
             time,
@@ -142,8 +165,7 @@ export default class WASI {
       },
       fd_close(fd: number): number {
         if (self.fds[fd] != undefined) {
-          let ret = self.fds[fd].fd_close();
-          // @ts-ignore
+          const ret = self.fds[fd].fd_close();
           self.fds[fd] = undefined;
           return ret;
         } else {
@@ -159,7 +181,7 @@ export default class WASI {
       },
       fd_fdstat_get(fd: number, fdstat_ptr: number): number {
         if (self.fds[fd] != undefined) {
-          let { ret, fdstat } = self.fds[fd].fd_fdstat_get();
+          const { ret, fdstat } = self.fds[fd].fd_fdstat_get();
           if (fdstat != null) {
             fdstat.write_bytes(
               new DataView(self.inst.exports.memory.buffer),
@@ -194,7 +216,7 @@ export default class WASI {
       },
       fd_filestat_get(fd: number, filestat_ptr: number): number {
         if (self.fds[fd] != undefined) {
-          let { ret, filestat } = self.fds[fd].fd_filestat_get();
+          const { ret, filestat } = self.fds[fd].fd_filestat_get();
           if (filestat != null) {
             filestat.write_bytes(
               new DataView(self.inst.exports.memory.buffer),
@@ -232,11 +254,15 @@ export default class WASI {
         offset: bigint,
         nread_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let iovecs = wasi.Iovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
-          let { ret, nread } = self.fds[fd].fd_pread(buffer8, iovecs, offset);
+          const iovecs = wasi.Iovec.read_bytes_array(
+            buffer,
+            iovs_ptr,
+            iovs_len,
+          );
+          const { ret, nread } = self.fds[fd].fd_pread(buffer8, iovecs, offset);
           buffer.setUint32(nread_ptr, nread, true);
           return ret;
         } else {
@@ -244,9 +270,9 @@ export default class WASI {
         }
       },
       fd_prestat_get(fd: number, buf_ptr: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let { ret, prestat } = self.fds[fd].fd_prestat_get();
+          const { ret, prestat } = self.fds[fd].fd_prestat_get();
           if (prestat != null) {
             prestat.write_bytes(buffer, buf_ptr);
           }
@@ -255,17 +281,18 @@ export default class WASI {
           return wasi.ERRNO_BADF;
         }
       },
+
       fd_prestat_dir_name(
         fd: number,
         path_ptr: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         path_len: number,
       ): number {
         // FIXME don't ignore path_len
         if (self.fds[fd] != undefined) {
-          // @ts-ignore
-          let { ret, prestat_dir_name } = self.fds[fd].fd_prestat_dir_name();
+          const { ret, prestat_dir_name } = self.fds[fd].fd_prestat_dir_name();
           if (prestat_dir_name != null) {
-            let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+            const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
             buffer8.set(prestat_dir_name, path_ptr);
           }
           return ret;
@@ -280,11 +307,15 @@ export default class WASI {
         offset: bigint,
         nwritten_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let iovecs = wasi.Ciovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
-          let { ret, nwritten } = self.fds[fd].fd_pwrite(
+          const iovecs = wasi.Ciovec.read_bytes_array(
+            buffer,
+            iovs_ptr,
+            iovs_len,
+          );
+          const { ret, nwritten } = self.fds[fd].fd_pwrite(
             buffer8,
             iovecs,
             offset,
@@ -301,11 +332,15 @@ export default class WASI {
         iovs_len: number,
         nread_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let iovecs = wasi.Iovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
-          let { ret, nread } = self.fds[fd].fd_read(buffer8, iovecs);
+          const iovecs = wasi.Iovec.read_bytes_array(
+            buffer,
+            iovs_ptr,
+            iovs_len,
+          );
+          const { ret, nread } = self.fds[fd].fd_read(buffer8, iovecs);
           buffer.setUint32(nread_ptr, nread, true);
           return ret;
         } else {
@@ -319,13 +354,14 @@ export default class WASI {
         cookie: bigint,
         bufused_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let bufused = 0;
 
+          // eslint-disable-next-line no-constant-condition
           while (true) {
-            let { ret, dirent } = self.fds[fd].fd_readdir_single(cookie);
+            const { ret, dirent } = self.fds[fd].fd_readdir_single(cookie);
             if (ret != 0) {
               buffer.setUint32(bufused_ptr, bufused, true);
               return ret;
@@ -339,7 +375,7 @@ export default class WASI {
               break;
             }
 
-            let head_bytes = new ArrayBuffer(dirent.head_length());
+            const head_bytes = new ArrayBuffer(dirent.head_length());
             dirent.write_head_bytes(new DataView(head_bytes), 0);
             buffer8.set(
               new Uint8Array(head_bytes).slice(
@@ -371,7 +407,7 @@ export default class WASI {
       },
       fd_renumber(fd: number, to: number) {
         if (self.fds[fd] != undefined && self.fds[to] != undefined) {
-          let ret = self.fds[to].fd_close();
+          const ret = self.fds[to].fd_close();
           if (ret != 0) {
             return ret;
           }
@@ -388,9 +424,9 @@ export default class WASI {
         whence: number,
         offset_out_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let { ret, offset: offset_out } = self.fds[fd].fd_seek(
+          const { ret, offset: offset_out } = self.fds[fd].fd_seek(
             offset,
             whence,
           );
@@ -408,9 +444,9 @@ export default class WASI {
         }
       },
       fd_tell(fd: number, offset_ptr: number): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let { ret, offset } = self.fds[fd].fd_tell();
+          const { ret, offset } = self.fds[fd].fd_tell();
           buffer.setBigUint64(offset_ptr, offset, true);
           return ret;
         } else {
@@ -423,11 +459,15 @@ export default class WASI {
         iovs_len: number,
         nwritten_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let iovecs = wasi.Ciovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
-          let { ret, nwritten } = self.fds[fd].fd_write(buffer8, iovecs);
+          const iovecs = wasi.Ciovec.read_bytes_array(
+            buffer,
+            iovs_ptr,
+            iovs_len,
+          );
+          const { ret, nwritten } = self.fds[fd].fd_write(buffer8, iovecs);
           buffer.setUint32(nwritten_ptr, nwritten, true);
           return ret;
         } else {
@@ -439,9 +479,9 @@ export default class WASI {
         path_ptr: number,
         path_len: number,
       ): number {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_create_directory(path);
@@ -454,13 +494,13 @@ export default class WASI {
         path_len: number,
         filestat_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
-          let { ret, filestat } = self.fds[fd].path_filestat_get(flags, path);
+          const { ret, filestat } = self.fds[fd].path_filestat_get(flags, path);
           if (filestat != null) {
             filestat.write_bytes(buffer, filestat_ptr);
           }
@@ -478,9 +518,9 @@ export default class WASI {
         mtim,
         fst_flags,
       ) {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_filestat_set_times(
@@ -503,12 +543,12 @@ export default class WASI {
         new_path_ptr: number,
         new_path_len: number,
       ): number {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[old_fd] != undefined && self.fds[new_fd] != undefined) {
-          let old_path = new TextDecoder("utf-8").decode(
+          const old_path = new TextDecoder("utf-8").decode(
             buffer8.slice(old_path_ptr, old_path_ptr + old_path_len),
           );
-          let new_path = new TextDecoder("utf-8").decode(
+          const new_path = new TextDecoder("utf-8").decode(
             buffer8.slice(new_path_ptr, new_path_ptr + new_path_len),
           );
           return self.fds[new_fd].path_link(
@@ -532,14 +572,14 @@ export default class WASI {
         fd_flags,
         opened_fd_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
-          //console.log(path);
-          let { ret, fd_obj } = self.fds[fd].path_open(
+          debug.log(path);
+          const { ret, fd_obj } = self.fds[fd].path_open(
             dirflags,
             path,
             oflags,
@@ -552,7 +592,7 @@ export default class WASI {
           }
           // FIXME use first free fd
           self.fds.push(fd_obj);
-          let opened_fd = self.fds.length - 1;
+          const opened_fd = self.fds.length - 1;
           buffer.setUint32(opened_fd_ptr, opened_fd, true);
           return 0;
         } else {
@@ -567,14 +607,14 @@ export default class WASI {
         buf_len: number,
         nread_ptr: number,
       ): number {
-        let buffer = new DataView(self.inst.exports.memory.buffer);
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer = new DataView(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
-          //console.log(path);
-          let { ret, data } = self.fds[fd].path_readlink(path);
+          debug.log(path);
+          const { ret, data } = self.fds[fd].path_readlink(path);
           if (data != null) {
             if (data.length > buf_len) {
               buffer.setUint32(nread_ptr, 0, true);
@@ -593,9 +633,9 @@ export default class WASI {
         path_ptr: number,
         path_len: number,
       ): number {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_remove_directory(path);
@@ -604,11 +644,17 @@ export default class WASI {
         }
       },
       path_rename(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         fd: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         old_path_ptr: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         old_path_len: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         new_fd: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         new_path_ptr: number,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         new_path_len: number,
       ): number {
         throw "FIXME what is the best abstraction for this?";
@@ -620,12 +666,12 @@ export default class WASI {
         new_path_ptr: number,
         new_path_len: number,
       ): number {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let old_path = new TextDecoder("utf-8").decode(
+          const old_path = new TextDecoder("utf-8").decode(
             buffer8.slice(old_path_ptr, old_path_ptr + old_path_len),
           );
-          let new_path = new TextDecoder("utf-8").decode(
+          const new_path = new TextDecoder("utf-8").decode(
             buffer8.slice(new_path_ptr, new_path_ptr + new_path_len),
           );
           return self.fds[fd].path_symlink(old_path, new_path);
@@ -634,9 +680,9 @@ export default class WASI {
         }
       },
       path_unlink_file(fd: number, path_ptr: number, path_len: number): number {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
-          let path = new TextDecoder("utf-8").decode(
+          const path = new TextDecoder("utf-8").decode(
             buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_unlink_file(path);
@@ -644,6 +690,7 @@ export default class WASI {
           return wasi.ERRNO_BADF;
         }
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       poll_oneoff(in_, out, nsubscriptions) {
         throw "async io not supported";
       },
@@ -655,20 +702,24 @@ export default class WASI {
       },
       sched_yield() {},
       random_get(buf: number, buf_len: number) {
-        let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         for (let i = 0; i < buf_len; i++) {
           buffer8[buf + i] = (Math.random() * 256) | 0;
         }
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       sock_recv(fd: number, ri_data, ri_flags) {
         throw "sockets not supported";
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       sock_send(fd: number, si_data, si_flags) {
         throw "sockets not supported";
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       sock_shutdown(fd: number, how) {
         throw "sockets not supported";
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       sock_accept(fd: number, flags) {
         throw "sockets not supported";
       },

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -5,7 +5,7 @@ type mixed = any;
 
 declare var TextEncoder: {
   prototype: TextEncoder;
-  new(encoding?: string): TextEncoder;
+  new (encoding?: string): TextEncoder;
 };
 
 export default class WASI {
@@ -26,7 +26,9 @@ export default class WASI {
   }
 
   /// Initialize a WASI reactor
-  initialize(instance: { exports: { memory: WebAssembly.Memory, _initialize: () => mixed } }) {
+  initialize(instance: {
+    exports: { memory: WebAssembly.Memory; _initialize: () => mixed };
+  }) {
     this.inst = instance;
     instance.exports._initialize();
   }
@@ -100,7 +102,7 @@ export default class WASI {
           buffer.setBigUint64(
             time,
             BigInt(new Date().getTime()) * 1000000n,
-            true
+            true,
           );
         } else if (id == wasi.CLOCKID_MONOTONIC) {
           let monotonic_time: bigint;
@@ -123,7 +125,7 @@ export default class WASI {
         fd: number,
         offset: bigint,
         len: bigint,
-        advice: number
+        advice: number,
       ): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_advise(offset, len, advice);
@@ -161,7 +163,7 @@ export default class WASI {
           if (fdstat != null) {
             fdstat.write_bytes(
               new DataView(self.inst.exports.memory.buffer),
-              fdstat_ptr
+              fdstat_ptr,
             );
           }
           return ret;
@@ -179,12 +181,12 @@ export default class WASI {
       fd_fdstat_set_rights(
         fd: number,
         fs_rights_base: bigint,
-        fs_rights_inheriting: bigint
+        fs_rights_inheriting: bigint,
       ): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_fdstat_set_rights(
             fs_rights_base,
-            fs_rights_inheriting
+            fs_rights_inheriting,
           );
         } else {
           return wasi.ERRNO_BADF;
@@ -196,7 +198,7 @@ export default class WASI {
           if (filestat != null) {
             filestat.write_bytes(
               new DataView(self.inst.exports.memory.buffer),
-              filestat_ptr
+              filestat_ptr,
             );
           }
           return ret;
@@ -215,7 +217,7 @@ export default class WASI {
         fd: number,
         atim: bigint,
         mtim: bigint,
-        fst_flags: number
+        fst_flags: number,
       ): number {
         if (self.fds[fd] != undefined) {
           return self.fds[fd].fd_filestat_set_times(atim, mtim, fst_flags);
@@ -228,7 +230,7 @@ export default class WASI {
         iovs_ptr: number,
         iovs_len: number,
         offset: bigint,
-        nread_ptr: number
+        nread_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
@@ -256,7 +258,7 @@ export default class WASI {
       fd_prestat_dir_name(
         fd: number,
         path_ptr: number,
-        path_len: number
+        path_len: number,
       ): number {
         // FIXME don't ignore path_len
         if (self.fds[fd] != undefined) {
@@ -276,7 +278,7 @@ export default class WASI {
         iovs_ptr: number,
         iovs_len: number,
         offset: bigint,
-        nwritten_ptr: number
+        nwritten_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
@@ -285,7 +287,7 @@ export default class WASI {
           let { ret, nwritten } = self.fds[fd].fd_pwrite(
             buffer8,
             iovecs,
-            offset
+            offset,
           );
           buffer.setUint32(nwritten_ptr, nwritten, true);
           return ret;
@@ -297,7 +299,7 @@ export default class WASI {
         fd: number,
         iovs_ptr: number,
         iovs_len: number,
-        nread_ptr: number
+        nread_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
@@ -315,7 +317,7 @@ export default class WASI {
         buf: number,
         buf_len: number,
         cookie: bigint,
-        bufused_ptr: number
+        bufused_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
@@ -340,7 +342,10 @@ export default class WASI {
             let head_bytes = new ArrayBuffer(dirent.head_length());
             dirent.write_head_bytes(new DataView(head_bytes), 0);
             buffer8.set(
-              (new Uint8Array(head_bytes)).slice(0, Math.min(head_bytes.byteLength, buf_len - bufused)),
+              new Uint8Array(head_bytes).slice(
+                0,
+                Math.min(head_bytes.byteLength, buf_len - bufused),
+              ),
               buf,
             );
             buf += dirent.head_length();
@@ -381,13 +386,13 @@ export default class WASI {
         fd: number,
         offset: bigint,
         whence: number,
-        offset_out_ptr: number
+        offset_out_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let { ret, offset: offset_out } = self.fds[fd].fd_seek(
             offset,
-            whence
+            whence,
           );
           buffer.setBigInt64(offset_out_ptr, offset_out, true);
           return ret;
@@ -416,7 +421,7 @@ export default class WASI {
         fd: number,
         iovs_ptr: number,
         iovs_len: number,
-        nwritten_ptr: number
+        nwritten_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
@@ -432,12 +437,12 @@ export default class WASI {
       path_create_directory(
         fd: number,
         path_ptr: number,
-        path_len: number
+        path_len: number,
       ): number {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_create_directory(path);
         }
@@ -447,13 +452,13 @@ export default class WASI {
         flags: number,
         path_ptr: number,
         path_len: number,
-        filestat_ptr: number
+        filestat_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           let { ret, filestat } = self.fds[fd].path_filestat_get(flags, path);
           if (filestat != null) {
@@ -471,19 +476,19 @@ export default class WASI {
         path_len: number,
         atim,
         mtim,
-        fst_flags
+        fst_flags,
       ) {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_filestat_set_times(
             flags,
             path,
             atim,
             mtim,
-            fst_flags
+            fst_flags,
           );
         } else {
           return wasi.ERRNO_BADF;
@@ -496,21 +501,21 @@ export default class WASI {
         old_path_len: number,
         new_fd: number,
         new_path_ptr: number,
-        new_path_len: number
+        new_path_len: number,
       ): number {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[old_fd] != undefined && self.fds[new_fd] != undefined) {
           let old_path = new TextDecoder("utf-8").decode(
-            buffer8.slice(old_path_ptr, old_path_ptr + old_path_len)
+            buffer8.slice(old_path_ptr, old_path_ptr + old_path_len),
           );
           let new_path = new TextDecoder("utf-8").decode(
-            buffer8.slice(new_path_ptr, new_path_ptr + new_path_len)
+            buffer8.slice(new_path_ptr, new_path_ptr + new_path_len),
           );
           return self.fds[new_fd].path_link(
             old_fd,
             old_flags,
             old_path,
-            new_path
+            new_path,
           );
         } else {
           return wasi.ERRNO_BADF;
@@ -525,13 +530,13 @@ export default class WASI {
         fs_rights_base,
         fs_rights_inheriting,
         fd_flags,
-        opened_fd_ptr: number
+        opened_fd_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           //console.log(path);
           let { ret, fd_obj } = self.fds[fd].path_open(
@@ -540,7 +545,7 @@ export default class WASI {
             oflags,
             fs_rights_base,
             fs_rights_inheriting,
-            fd_flags
+            fd_flags,
           );
           if (ret != 0) {
             return ret;
@@ -560,13 +565,13 @@ export default class WASI {
         path_len: number,
         buf_ptr: number,
         buf_len: number,
-        nread_ptr: number
+        nread_ptr: number,
       ): number {
         let buffer = new DataView(self.inst.exports.memory.buffer);
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           //console.log(path);
           let { ret, data } = self.fds[fd].path_readlink(path);
@@ -586,12 +591,12 @@ export default class WASI {
       path_remove_directory(
         fd: number,
         path_ptr: number,
-        path_len: number
+        path_len: number,
       ): number {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_remove_directory(path);
         } else {
@@ -604,7 +609,7 @@ export default class WASI {
         old_path_len: number,
         new_fd: number,
         new_path_ptr: number,
-        new_path_len: number
+        new_path_len: number,
       ): number {
         throw "FIXME what is the best abstraction for this?";
       },
@@ -613,15 +618,15 @@ export default class WASI {
         old_path_len: number,
         fd: number,
         new_path_ptr: number,
-        new_path_len: number
+        new_path_len: number,
       ): number {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let old_path = new TextDecoder("utf-8").decode(
-            buffer8.slice(old_path_ptr, old_path_ptr + old_path_len)
+            buffer8.slice(old_path_ptr, old_path_ptr + old_path_len),
           );
           let new_path = new TextDecoder("utf-8").decode(
-            buffer8.slice(new_path_ptr, new_path_ptr + new_path_len)
+            buffer8.slice(new_path_ptr, new_path_ptr + new_path_len),
           );
           return self.fds[fd].path_symlink(old_path, new_path);
         } else {
@@ -632,7 +637,7 @@ export default class WASI {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         if (self.fds[fd] != undefined) {
           let path = new TextDecoder("utf-8").decode(
-            buffer8.slice(path_ptr, path_ptr + path_len)
+            buffer8.slice(path_ptr, path_ptr + path_len),
           );
           return self.fds[fd].path_unlink_file(path);
         } else {
@@ -648,7 +653,7 @@ export default class WASI {
       proc_raise(sig: number) {
         throw "raised signal " + sig;
       },
-      sched_yield() { },
+      sched_yield() {},
       random_get(buf: number, buf_len: number) {
         let buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         for (let i = 0; i < buf_len; i++) {

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -131,7 +131,7 @@ export class Iovec {
   static read_bytes_array(
     view: DataView,
     ptr: number,
-    len: number
+    len: number,
   ): Array<Iovec> {
     let iovecs = [];
     for (let i = 0; i < len; i++) {
@@ -155,7 +155,7 @@ export class Ciovec {
   static read_bytes_array(
     view: DataView,
     ptr: number,
-    len: number
+    len: number,
   ): Array<Ciovec> {
     let iovecs = [];
     for (let i = 0; i < len; i++) {
@@ -217,7 +217,10 @@ export class Dirent {
   }
 
   write_name_bytes(view8: Uint8Array, ptr: number, buf_len: number) {
-    view8.set(this.dir_name.slice(0, Math.min(this.dir_name.byteLength, buf_len)), ptr);
+    view8.set(
+      this.dir_name.slice(0, Math.min(this.dir_name.byteLength, buf_len)),
+      ptr,
+    );
   }
 }
 

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -122,7 +122,7 @@ export class Iovec {
   buf_len: number;
 
   static read_bytes(view: DataView, ptr: number): Iovec {
-    let iovec = new Iovec();
+    const iovec = new Iovec();
     iovec.buf = view.getUint32(ptr, true);
     iovec.buf_len = view.getUint32(ptr + 4, true);
     return iovec;
@@ -133,7 +133,7 @@ export class Iovec {
     ptr: number,
     len: number,
   ): Array<Iovec> {
-    let iovecs = [];
+    const iovecs = [];
     for (let i = 0; i < len; i++) {
       iovecs.push(Iovec.read_bytes(view, ptr + 8 * i));
     }
@@ -146,7 +146,7 @@ export class Ciovec {
   buf_len: number;
 
   static read_bytes(view: DataView, ptr: number): Ciovec {
-    let iovec = new Ciovec();
+    const iovec = new Ciovec();
     iovec.buf = view.getUint32(ptr, true);
     iovec.buf_len = view.getUint32(ptr + 4, true);
     return iovec;
@@ -157,7 +157,7 @@ export class Ciovec {
     ptr: number,
     len: number,
   ): Array<Ciovec> {
-    let iovecs = [];
+    const iovecs = [];
     for (let i = 0; i < len; i++) {
       iovecs.push(Ciovec.read_bytes(view, ptr + 8 * i));
     }
@@ -178,11 +178,6 @@ export const FILETYPE_SOCKET_DGRAM = 5;
 export const FILETYPE_SOCKET_STREAM = 6;
 export const FILETYPE_SYMBOLIC_LINK = 7;
 
-declare var TextEncoder: {
-  prototype: TextEncoder;
-  new (encoding?: string): TextEncoder;
-};
-
 export class Dirent {
   d_next: bigint;
   d_ino: bigint = 1n;
@@ -191,7 +186,7 @@ export class Dirent {
   dir_name: Uint8Array;
 
   constructor(next_cookie: bigint, name: string, type: number) {
-    let encoded_name = new TextEncoder("utf-8").encode(name);
+    const encoded_name = new TextEncoder().encode(name);
 
     this.d_next = next_cookie;
     this.d_namlen = encoded_name.byteLength;
@@ -208,9 +203,7 @@ export class Dirent {
   }
 
   write_head_bytes(view: DataView, ptr: number) {
-    // @ts-ignore
     view.setBigUint64(ptr, this.d_next, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 8, this.d_ino, true);
     view.setUint32(ptr + 16, this.dir_name.length, true); // d_namlen
     view.setUint8(ptr + 20, this.d_type);
@@ -251,9 +244,7 @@ export class Fdstat {
   write_bytes(view: DataView, ptr: number) {
     view.setUint8(ptr, this.fs_filetype);
     view.setUint16(ptr + 2, this.fs_flags, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 8, this.fs_rights_base, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 16, this.fs_rights_inherited, true);
   }
 }
@@ -284,20 +275,13 @@ export class Filestat {
   }
 
   write_bytes(view: DataView, ptr: number) {
-    // @ts-ignore
     view.setBigUint64(ptr, this.dev, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 8, this.ino, true);
     view.setUint8(ptr + 16, this.filetype);
-    // @ts-ignore
     view.setBigUint64(ptr + 24, this.nlink, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 32, this.size, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 38, this.atim, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 46, this.mtim, true);
-    // @ts-ignore
     view.setBigUint64(ptr + 52, this.ctim, true);
   }
 }
@@ -369,7 +353,7 @@ export class Prestat {
   inner: PrestatDir;
 
   static dir(name_len: number): Prestat {
-    let prestat = new Prestat();
+    const prestat = new Prestat();
     prestat.tag = PREOPENTYPE_DIR;
     prestat.inner = new PrestatDir(name_len);
     return prestat;


### PR DESCRIPTION
Thank you for this project @bjorn3!

This PR looks like a lot but has mostly cosmetic changes and is broken down into three commits:

- Formatting:
  -  Formatted code with `prettier`
  - Added .prettierrc configuration to prefer double quotes over single.
  - Added formatting validation to the `check` task
- Linting/types
  - Added eslint and recommended TypeScript lints
  - Fixed lint errors (mostly let vs. const and unused variables)
  - Fixed issues where TypeScript typings were being ignored.
  - Added eslint to the `check` task
- README/Demo:
  - Found the [wasm-rustc](https://github.com/rust-lang/miri/issues/722#issuecomment-1584287506) tarball and archived the contents [here](https://github.com/jsoverson/wasm-rustc). I can transfer that repo to you as it makes more sense here.
  - Added that repo as a git submodule
  - Added README documentation to show how to build the project and run the demo locally.

I can break this PR down into three separate PRs if necessary.