### PR TITLE
feat: Add stdout/stderr Fd class

### DIFF
--- a/src/fs_fd.ts
+++ b/src/fs_fd.ts
@@ -113,6 +113,29 @@ export class OpenFile extends Fd {
   }
 }
 
+/**
+ * A file that is opened as a standard output/error stream.
+ */
+export class Stdout extends Fd {
+  constructor() {
+    super();
+  }
+
+  fd_filestat_get() {
+    const filestat = new wasi.Filestat(
+      wasi.FILETYPE_CHARACTER_DEVICE,
+      BigInt(0),
+    );
+    return { ret: 0, filestat };
+  }
+
+  fd_fdstat_get() {
+    const fdstat = new wasi.Fdstat(wasi.FILETYPE_CHARACTER_DEVICE, 0);
+    fdstat.fs_rights_base = BigInt(wasi.RIGHTS_FD_WRITE);
+    return { ret: 0, fdstat };
+  }
+}
+
 export class OpenSyncOPFSFile extends Fd {
   file: SyncOPFSFile;
   position: bigint = 0n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export {
   OpenDirectory,
   OpenSyncOPFSFile,
   PreopenDirectory,
+  Stdout,
 } from "./fs_fd.js";
 export { strace } from "./strace.js";


### PR DESCRIPTION
stdout/stderr should provide proper rights and filetype because wasi-libc still respects them in `fcntl`.