### PR TITLE
fix: Return 0 from `WASI.start()` on success

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -30,6 +30,7 @@ export default class WASI {
     this.inst = instance;
     try {
       instance.exports._start();
+      return 0;
     } catch (e) {
       if (e instanceof WASIProcExit) {
         return e.code;


### PR DESCRIPTION
This behavior is consistent with Node.js's `WASI.start()`. https://github.com/nodejs/node/blob/v21.4.0/lib/wasi.js#L117