### PR TITLE
Add default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "types": "./typings/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "typings": "./typings/index.d.ts",


### PR DESCRIPTION
This should allow importing it using old style CJS include()

Fixes #64