### PR TITLE
Handle `_initialize` non existence in wasi reactor modules

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -43,10 +43,12 @@ export default class WASI {
 
   /// Initialize a WASI reactor
   initialize(instance: {
-    exports: { memory: WebAssembly.Memory; _initialize: () => unknown };
+    exports: { memory: WebAssembly.Memory; _initialize?: () => unknown };
   }) {
     this.inst = instance;
-    instance.exports._initialize();
+    if (instance.exports._initialize) {
+      instance.exports._initialize();
+    }
   }
 
   constructor(


### PR DESCRIPTION
The `_initialize` export is optional and may not exist in a wasi reactor module, according to https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi. When it doesn't exist, simply don't do anything. This is especially useful in cases where a module has been pre-initialized by `wizer` and the `_initialize` export has been stripped.