### PR TITLE
fix: reexport the WASIProcExit error so it can be caught when calling exported functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import WASI from "./wasi.js";
-export { WASI };
+import WASI, { WASIProcExit } from "./wasi.js";
+export { WASI, WASIProcExit };
 
 export { Fd } from "./fd.js";
 export {


### PR DESCRIPTION
So you can do
```js
    try {
      instance.exports.my_exported_func();
      return 0;
    } catch (e) {
      if (e instanceof WASIProcExit) {
        return e.code;
      } else {
        throw e;
      }
    }
```