### PR TITLE
Modify random_get to use crypto.getRandomValues

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -826,20 +826,16 @@ export default class WASI {
       },
       sched_yield() {},
       random_get(buf: number, buf_len: number) {
-        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
-        const end = buf + buf_len;
+        const buffer8 = new Uint8Array(
+          self.inst.exports.memory.buffer,
+        ).subarray(buf, buf + buf_len);
 
         if (self.hasCrypto) {
-          let i = buf;
-          for (; i < end; ) {
-            const next_i = i + 65_536;
-            crypto.getRandomValues(
-              buffer8.subarray(i, next_i > end ? end : next_i),
-            );
-            i = next_i;
+          for (let i = 0; i < buf_len; i += 65536) {
+            crypto.getRandomValues(buffer8.subarray(i, i + 65536));
           }
         } else {
-          for (let i = buf; i < end; i++) {
+          for (let i = 0; i < buf_len; i++) {
             buffer8[i] = (Math.random() * 256) | 0;
           }
         }

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -829,7 +829,7 @@ export default class WASI {
         const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         const end = buf + buf_len;
 
-        if (this.hasCrypto) {
+        if (self.hasCrypto) {
           let i = buf;
           for (; i < buf_len; ) {
             const next_i = i + 65_536;

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -22,7 +22,6 @@ export default class WASI {
   inst: { exports: { memory: WebAssembly.Memory } };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wasiImport: { [key: string]: (...args: Array<any>) => unknown };
-  private readonly hasCrypto: boolean = "crypto" in Function("return this")();
 
   /// Start a WASI command
   start(instance: {
@@ -830,7 +829,7 @@ export default class WASI {
           self.inst.exports.memory.buffer,
         ).subarray(buf, buf + buf_len);
 
-        if (self.hasCrypto) {
+        if ("crypto" in globalThis) {
           for (let i = 0; i < buf_len; i += 65536) {
             crypto.getRandomValues(buffer8.subarray(i, i + 65536));
           }

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -22,6 +22,7 @@ export default class WASI {
   inst: { exports: { memory: WebAssembly.Memory } };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wasiImport: { [key: string]: (...args: Array<any>) => unknown };
+  private hasCrypto: boolean = "crypto" in Function("return this")();
 
   /// Start a WASI command
   start(instance: {
@@ -828,7 +829,7 @@ export default class WASI {
         const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
         const end = buf + buf_len;
 
-        if ("crypto" in global) {
+        if (this.hasCrypto) {
           let i = buf;
           for (; i < buf_len; ) {
             const next_i = i + 65_536;

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -825,9 +825,17 @@ export default class WASI {
       },
       sched_yield() {},
       random_get(buf: number, buf_len: number) {
-        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
-        for (let i = 0; i < buf_len; i++) {
-          buffer8[buf + i] = (Math.random() * 256) | 0;
+        const buffer8 = new Uint8Array(
+          self.inst.exports.memory.buffer,
+        ).subarray(buf, buf + buf_len);
+
+        let i = 0;
+        for (; i < buf_len; ) {
+          const next_i = i + 65_536;
+          globalThis.crypto.getRandomValues(
+            buffer8.subarray(i, next_i > buf_len ? buf_len : next_i),
+          );
+          i = next_i;
         }
       },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -832,7 +832,7 @@ export default class WASI {
         let i = 0;
         for (; i < buf_len; ) {
           const next_i = i + 65_536;
-          globalThis.crypto.getRandomValues(
+          crypto.getRandomValues(
             buffer8.subarray(i, next_i > buf_len ? buf_len : next_i),
           );
           i = next_i;

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -825,17 +825,22 @@ export default class WASI {
       },
       sched_yield() {},
       random_get(buf: number, buf_len: number) {
-        const buffer8 = new Uint8Array(
-          self.inst.exports.memory.buffer,
-        ).subarray(buf, buf + buf_len);
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        const end = buf + buf_len;
 
-        let i = 0;
-        for (; i < buf_len; ) {
-          const next_i = i + 65_536;
-          crypto.getRandomValues(
-            buffer8.subarray(i, next_i > buf_len ? buf_len : next_i),
-          );
-          i = next_i;
+        if ("crypto" in global) {
+          let i = buf;
+          for (; i < buf_len; ) {
+            const next_i = i + 65_536;
+            crypto.getRandomValues(
+              buffer8.subarray(i, next_i > end ? end : next_i),
+            );
+            i = next_i;
+          }
+        } else {
+          for (let i = buf; i < end; i++) {
+            buffer8[i] = (Math.random() * 256) | 0;
+          }
         }
       },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -22,7 +22,7 @@ export default class WASI {
   inst: { exports: { memory: WebAssembly.Memory } };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wasiImport: { [key: string]: (...args: Array<any>) => unknown };
-  private hasCrypto: boolean = "crypto" in Function("return this")();
+  private readonly hasCrypto: boolean = "crypto" in Function("return this")();
 
   /// Start a WASI command
   start(instance: {
@@ -831,7 +831,7 @@ export default class WASI {
 
         if (self.hasCrypto) {
           let i = buf;
-          for (; i < buf_len; ) {
+          for (; i < end; ) {
             const next_i = i + 65_536;
             crypto.getRandomValues(
               buffer8.subarray(i, next_i > end ? end : next_i),


### PR DESCRIPTION
I simply modified the `random_get` implementation to use `crypto.getRandomValues` to generate the random numbers.
This has the benefit that the RNG is cryptographically secure, and is probably faster that the previous implementation (though that should be benchmarked).