### PR TITLE
Prevent using crypto for SharedArrayBuffer

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -829,7 +829,10 @@ export default class WASI {
           self.inst.exports.memory.buffer,
         ).subarray(buf, buf + buf_len);
 
-        if ("crypto" in globalThis) {
+        if (
+          "crypto" in globalThis &&
+          !(self.inst.exports.memory.buffer instanceof SharedArrayBuffer)
+        ) {
           for (let i = 0; i < buf_len; i += 65536) {
             crypto.getRandomValues(buffer8.subarray(i, i + 65536));
           }


### PR DESCRIPTION
Related issue: https://github.com/w3c/webcrypto/issues/213

In chrome, Crypto doesn't work with SharedArrayBuffer. it makes error `The provided ArrayBufferView value must not be shared.`.

I suggest to use previous Math random code when memory is SharedArrayBuffer.