### PR TITLE
Define top-level "main" and "types" fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "bugs": {
     "url": "https://github.com/bjorn3/browser_wasi_shim/issues"
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./typings/index.d.ts",


### PR DESCRIPTION
Some of bundler tools like Parcel do not support the "exports" field yet. This change defines the top-level "main" and "types" fields in package.json as a fallback.