### PR TITLE
Return unique ino for each node for `Filestat` and `Dirent`

### DIFF
--- a/src/fd.ts
+++ b/src/fd.ts
@@ -116,7 +116,31 @@ export abstract class Fd {
   }
 }
 
+class InoIssuer {
+  // NOTE: ino 0 is reserved for the root directory
+  private next_ino: bigint = 1n;
+
+  issue(_node: unknown): bigint {
+    // TODO: consider recycling ino if the node is deallocated
+    return this.next_ino++;
+  }
+}
+
 export abstract class Inode {
+  ino: bigint;
+
+  constructor() {
+    this.ino = Inode.issue_ino(this);
+  }
+
+  static default_issuer = new InoIssuer();
+  static issue_ino(node: unknown): bigint {
+    return Inode.default_issuer.issue(node);
+  }
+  static root_ino(): bigint {
+    return 0n;
+  }
+
   abstract path_open(
     oflags: number,
     fs_rights_base: bigint,

--- a/src/fd.ts
+++ b/src/fd.ts
@@ -116,26 +116,17 @@ export abstract class Fd {
   }
 }
 
-class InoIssuer {
-  // NOTE: ino 0 is reserved for the root directory
-  private next_ino: bigint = 1n;
-
-  issue(_node: unknown): bigint {
-    // TODO: consider recycling ino if the node is deallocated
-    return this.next_ino++;
-  }
-}
-
 export abstract class Inode {
   ino: bigint;
 
   constructor() {
-    this.ino = Inode.issue_ino(this);
+    this.ino = Inode.issue_ino();
   }
 
-  static default_issuer = new InoIssuer();
-  static issue_ino(node: unknown): bigint {
-    return Inode.default_issuer.issue(node);
+  // NOTE: ino 0 is reserved for the root directory
+  private static next_ino: bigint = 1n;
+  static issue_ino(): bigint {
+    return Inode.next_ino++;
   }
   static root_ino(): bigint {
     return 0n;

--- a/src/fs_mem.ts
+++ b/src/fs_mem.ts
@@ -726,7 +726,7 @@ export class ConsoleStdout extends Fd {
 
   constructor(write: (buffer: Uint8Array) => void) {
     super();
-    this.ino = Inode.issue_ino(this);
+    this.ino = Inode.issue_ino();
     this.write = write;
   }
 

--- a/src/fs_opfs.ts
+++ b/src/fs_opfs.ts
@@ -70,7 +70,7 @@ export class OpenSyncOPFSFile extends Fd {
   constructor(file: SyncOPFSFile) {
     super();
     this.file = file;
-    this.ino = Inode.issue_ino(this);
+    this.ino = Inode.issue_ino();
   }
 
   fd_allocate(offset: bigint, len: bigint): number {

--- a/src/fs_opfs.ts
+++ b/src/fs_opfs.ts
@@ -58,17 +58,19 @@ export class SyncOPFSFile extends Inode {
   }
 
   stat(): wasi.Filestat {
-    return new wasi.Filestat(wasi.FILETYPE_REGULAR_FILE, this.size);
+    return new wasi.Filestat(this.ino, wasi.FILETYPE_REGULAR_FILE, this.size);
   }
 }
 
 export class OpenSyncOPFSFile extends Fd {
   file: SyncOPFSFile;
   position: bigint = 0n;
+  ino: bigint;
 
   constructor(file: SyncOPFSFile) {
     super();
     this.file = file;
+    this.ino = Inode.issue_ino(this);
   }
 
   fd_allocate(offset: bigint, len: bigint): number {
@@ -89,6 +91,7 @@ export class OpenSyncOPFSFile extends Fd {
     return {
       ret: 0,
       filestat: new wasi.Filestat(
+        this.ino,
         wasi.FILETYPE_REGULAR_FILE,
         BigInt(this.file.handle.getSize()),
       ),

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -184,15 +184,16 @@ export const FILETYPE_SYMBOLIC_LINK = 7;
 
 export class Dirent {
   d_next: bigint;
-  d_ino: bigint = 0n;
+  d_ino: bigint;
   d_namlen: number;
   d_type: number;
   dir_name: Uint8Array;
 
-  constructor(next_cookie: bigint, name: string, type: number) {
+  constructor(next_cookie: bigint, d_ino: bigint, name: string, type: number) {
     const encoded_name = new TextEncoder().encode(name);
 
     this.d_next = next_cookie;
+    this.d_ino = d_ino;
     this.d_namlen = encoded_name.byteLength;
     this.d_type = type;
     this.dir_name = encoded_name;
@@ -265,7 +266,7 @@ export const OFLAGS_TRUNC = 1 << 3;
 
 export class Filestat {
   dev: bigint = 0n;
-  ino: bigint = 0n;
+  ino: bigint;
   filetype: number;
   nlink: bigint = 0n;
   size: bigint;
@@ -273,7 +274,8 @@ export class Filestat {
   mtim: bigint = 0n;
   ctim: bigint = 0n;
 
-  constructor(filetype: number, size: bigint) {
+  constructor(ino: bigint, filetype: number, size: bigint) {
+    this.ino = ino;
     this.filetype = filetype;
     this.size = size;
   }

--- a/test/adapters/node/run-wasi.mjs
+++ b/test/adapters/node/run-wasi.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs/promises';
-import { WASI, wasi, strace, OpenFile, File, Directory, PreopenDirectory, Fd } from "../../../dist/index.js"
+import { WASI, wasi, strace, OpenFile, File, Directory, PreopenDirectory, Fd, Inode } from "../../../dist/index.js"
 import { parseArgs } from "../shared/parseArgs.mjs"
 import { walkFs } from "../shared/walkFs.mjs"
 
@@ -9,10 +9,12 @@ class NodeStdout extends Fd {
   constructor(out) {
     super();
     this.out = out;
+    this.ino = Inode.issue_ino();
   }
 
   fd_filestat_get() {
     const filestat = new wasi.Filestat(
+      this.ino,
       wasi.FILETYPE_CHARACTER_DEVICE,
       BigInt(0),
     );

--- a/threads/src/shared_array_buffer/ref.ts
+++ b/threads/src/shared_array_buffer/ref.ts
@@ -521,9 +521,8 @@ export class WASIFarmRefUseArrayBuffer extends WASIFarmRef {
 
     this.release_fd(fd);
 
-    const file_stat = new wasi.Filestat(fs_filetype, fs_size);
+    const file_stat = new wasi.Filestat(fs_ino, fs_filetype, fs_size);
     file_stat.dev = fs_dev;
-    file_stat.ino = fs_ino;
     file_stat.nlink = fs_nlink;
     file_stat.atim = fs_atim;
     file_stat.mtim = fs_mtim;
@@ -1092,9 +1091,8 @@ export class WASIFarmRefUseArrayBuffer extends WASIFarmRef {
 
     this.release_fd(fd);
 
-    const file_stat = new wasi.Filestat(fs_filetype, fs_size);
+    const file_stat = new wasi.Filestat(fs_ino, fs_filetype, fs_size);
     file_stat.dev = fs_dev;
-    file_stat.ino = fs_ino;
     file_stat.nlink = fs_nlink;
     file_stat.atim = fs_atim;
     file_stat.mtim = fs_mtim;


### PR DESCRIPTION
Some applications rely on the ino's uniqueness to identify a file. For example, musl-fts uses ino to detect a cycle in the directory tree, and it now wrongly detects a cycle with this WASI impl because the ino is always 0. This change makes the ino unique for each node.