### PR TITLE
fs_mem: fix directory parent pointers

### DIFF
--- a/src/fs_mem.ts
+++ b/src/fs_mem.ts
@@ -338,6 +338,9 @@ export class OpenDirectory extends Fd {
       return wasi.ERRNO_PERM;
     }
 
+    if (inode instanceof Directory) {
+      inode.parent = parent_entry;
+    }
     parent_entry.contents.set(filename, inode);
 
     return wasi.ERRNO_SUCCESS;
@@ -557,7 +560,7 @@ class Path {
 
 export class Directory extends Inode {
   contents: Map<string, Inode>;
-  private parent: Directory | null = null;
+  parent: Directory | null = null;
 
   constructor(contents: Map<string, Inode> | [string, Inode][]) {
     super();
@@ -712,6 +715,7 @@ export class Directory extends Inode {
       new_child = new File(new ArrayBuffer(0));
     } else {
       new_child = new Directory(new Map());
+      new_child.parent = parent_entry;
     }
     parent_entry.contents.set(filename, new_child);
     entry = new_child;


### PR DESCRIPTION
In some cases, a directory inode's `parent` field is not properly set, this patch adds the missing cases.