### PR TITLE
Draft: Patch to get this working in modern browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 typings/
 .vscode/
+__pycache__

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,7 +687,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.24"
@@ -1003,7 +1002,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1366,7 +1364,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1813,7 +1810,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3404,7 +3400,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3476,7 +3471,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -887,19 +887,8 @@ export default class WASI {
         const buffer8 = new Uint8Array(
           self.inst.exports.memory.buffer,
         ).subarray(buf, buf + buf_len);
-
-        if (
-          "crypto" in globalThis &&
-          (typeof SharedArrayBuffer === "undefined" ||
-            !(self.inst.exports.memory.buffer instanceof SharedArrayBuffer))
-        ) {
-          for (let i = 0; i < buf_len; i += 65536) {
-            crypto.getRandomValues(buffer8.subarray(i, i + 65536));
-          }
-        } else {
-          for (let i = 0; i < buf_len; i++) {
-            buffer8[i] = (Math.random() * 256) | 0;
-          }
+        for (let i = 0; i < buf_len; i++) {
+          buffer8[i] = (Math.random() * 256) | 0;
         }
       },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
In some browsers access SharedArrayBuffer is no longer allowed. (citation needed). This removes the call to SharedArrayBuffer in our WASI shim to get around that.