### PR TITLE
Fix atim/mtim/ctim handling of in-memory vfs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { Fd, Inode } from "./fd.js";
 export {
   File,
   Directory,
+  InodeMem,
   OpenFile,
   OpenDirectory,
   PreopenDirectory,

--- a/src/wasi_defs.ts
+++ b/src/wasi_defs.ts
@@ -270,14 +270,24 @@ export class Filestat {
   filetype: number;
   nlink: bigint = 0n;
   size: bigint;
-  atim: bigint = 0n;
-  mtim: bigint = 0n;
-  ctim: bigint = 0n;
+  atim: bigint;
+  mtim: bigint;
+  ctim: bigint;
 
-  constructor(ino: bigint, filetype: number, size: bigint) {
+  constructor(
+    ino: bigint,
+    filetype: number,
+    size: bigint,
+    atim: bigint = 0n,
+    mtim: bigint = 0n,
+    ctim: bigint = 0n,
+  ) {
     this.ino = ino;
     this.filetype = filetype;
     this.size = size;
+    this.atim = atim;
+    this.mtim = mtim;
+    this.ctim = ctim;
   }
 
   write_bytes(view: DataView, ptr: number) {


### PR DESCRIPTION
This patch fixes atim/mtim/ctim handling of in-memory vfs:

- Add `InodeMem` as the inode base class of in-memory vfs that tracks timestamps
- Add atim/mtim/ctim arguments to `Filestat` constructor, and construct the right `Filestat` object when needed