### PR TITLE
Fix args_sizes_get using JS string length instead of UTF-8 byte length

### DIFF
--- a/src/wasi.ts
+++ b/src/wasi.ts
@@ -71,7 +71,7 @@ export default class WASI {
         buffer.setUint32(argc, self.args.length, true);
         let buf_size = 0;
         for (const arg of self.args) {
-          buf_size += arg.length + 1;
+          buf_size += new TextEncoder().encode(arg).length + 1;
         }
         buffer.setUint32(argv_buf_size, buf_size, true);
         debug.log(

--- a/threads/src/animals.ts
+++ b/threads/src/animals.ts
@@ -433,7 +433,7 @@ export class WASIFarmAnimal {
         buffer.setUint32(argc, self.args.length, true);
         let buf_size = 0;
         for (const arg of self.args) {
-          buf_size += arg.length + 1;
+          buf_size += new TextEncoder().encode(arg).length + 1;
         }
         buffer.setUint32(argv_buf_size, buf_size, true);
         return 0;
@@ -463,7 +463,7 @@ export class WASIFarmAnimal {
         buffer.setUint32(environ_count, self.env.length, true);
         let buf_size = 0;
         for (const environ of self.env) {
-          buf_size += environ.length + 1;
+          buf_size += new TextEncoder().encode(environ).length + 1;
         }
         buffer.setUint32(environ_size, buf_size, true);
         return 0;


### PR DESCRIPTION
Closes: #109 